### PR TITLE
feat: full-page booking chat at /booking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -354,6 +354,21 @@ const isDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
 const isRTL = /[\u0590-\u05FF]/.test(text);
 ```
 
+### Styling (CSS Variables — NOT hardcoded Tailwind)
+
+UI components use CSS custom property aliases set by the theme effect:
+- `bg-primary` / `text-primary` / `border-primary` — main brand color
+- `bg-accent` / `text-accent` — accent/button color
+- `bg-surface` — page/chat background
+
+Do NOT use `bg-fattalNavy`, `bg-fattalGold`, `bg-fattalCream` etc. in new components.
+
+### Theme Interface (`src/config/theme-config.ts`)
+
+`WidgetTheme` has NO `countryCodes`, `phoneLabel`, `phonePlaceholder`, or `phoneError`.
+The name form collects name only — no phone field.
+`sendMessageToAPI` signature: `(message, userName, formData?)` — no `userPhone`.
+
 ---
 
 ## Configuration
@@ -421,6 +436,23 @@ const nextConfig = {
 
 ---
 
+## Poll API & Full-Page Chat
+
+### Poll API Response Shape
+
+`GET /api/widget/poll?conversationId=xxx` returns `{ success: true, data: { message, hotelOptions, ... } }`
+Always unwrap: `const data = body.data` — checking `body.message` directly won't work.
+Returns `{ success: true, data: null }` when queue is empty.
+
+### Full-Page Booking Chat (`/booking`)
+
+`src/app/booking/page.tsx` + `src/components/FullPageChatWidget.tsx` — standalone full-page chat
+accessible at `widget.ersona.co/booking?widgetId=<companyId>&theme=<themeId>`.
+`FullPageChatWidget` calls APIs directly (no postMessage/iframe) and runs its own 2.5s poll loop.
+No infra changes needed — served by the same deployment as the embed widget.
+
+---
+
 ## Troubleshooting
 
 ### CORS Errors
@@ -457,6 +489,8 @@ const nextConfig = {
 |------|-------|
 | API Routes | `src/app/api/widget/*/route.ts` |
 | Embed Page | `src/app/embed-chat/page.tsx` |
+| Booking Page | `src/app/booking/page.tsx` |
+| Full-Page Widget | `src/components/FullPageChatWidget.tsx` |
 | Components | `src/components/*.tsx` |
 | Pusher Service | `src/services/pusher-service.ts` |
 | Redis Service | `src/services/redis-service.ts` |

--- a/src/app/booking/page.tsx
+++ b/src/app/booking/page.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Suspense } from "react";
+import { useSearchParams } from "next/navigation";
+import FullPageChatWidget from "@/components/FullPageChatWidget";
+
+function BookingContent() {
+  const searchParams = useSearchParams();
+  const widgetId = searchParams.get("widgetId") ?? "";
+  const theme = searchParams.get("theme");
+
+  if (!widgetId) {
+    return (
+      <div className="h-screen w-screen flex items-center justify-center bg-gray-50">
+        <p className="text-gray-500 text-sm">Missing widgetId parameter.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-screen w-screen overflow-hidden">
+      <FullPageChatWidget widgetId={widgetId} theme={theme} />
+    </div>
+  );
+}
+
+export default function BookingPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="h-screen w-full flex items-center justify-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-fattalNavy" />
+        </div>
+      }
+    >
+      <BookingContent />
+    </Suspense>
+  );
+}

--- a/src/components/FullPageChatWidget.tsx
+++ b/src/components/FullPageChatWidget.tsx
@@ -1,0 +1,594 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { LuSendHorizontal } from "react-icons/lu";
+import Image from "next/image";
+import Markdown from "react-markdown";
+import LoadingSpinner from "./LoadingSpinner";
+import { FattalHotel, FattalRoom, FattalRoomPackage, FattalPackagePrice, WidgetListing, ContactFormConfig } from "@/types/message-types";
+import HotelCarousel from "./HotelCarousel";
+import FattalRoomCarousel from "./FattalRoomCarousel";
+import FattalRoomDetailView from "./FattalRoomDetailView";
+import ListingCarousel from "./ListingCarousel";
+import ListingDetailView from "./ListingDetailView";
+import ContactForm from "./ContactForm";
+import { Language, t, formatPrice as formatPriceI18n, parseLanguageCode } from "@/utils/i18n";
+import { getTheme } from "@/config/theme-config";
+
+interface Message {
+  id: string;
+  text: string;
+  sender: "user" | "bot";
+  timestamp: Date;
+  direction: "ltr" | "rtl";
+  hotelOptions?: FattalHotel[];
+  roomSearchResults?: FattalRoom[];
+  listingOptions?: WidgetListing[];
+  contactForm?: ContactFormConfig;
+  languageCode?: string;
+}
+
+const HEBREW_REGEX = /[\u0590-\u05FF]/;
+const POLLING_INTERVAL_MS = 2500;
+const INACTIVITY_TIMEOUT_MS = 60 * 60 * 1000; // 1 hour
+
+const detectTextDirection = (text: string): "ltr" | "rtl" => {
+  return HEBREW_REGEX.test(text.charAt(0)) ? "rtl" : "ltr";
+};
+
+const MarkdownLink = ({ href, children, isUserMessage }: { href?: string; children: React.ReactNode; isUserMessage: boolean }) => (
+  <a
+    href={href}
+    target="_blank"
+    rel="noopener noreferrer"
+    className={`underline hover:no-underline transition-colors font-medium ${
+      isUserMessage
+        ? "text-primary/80 hover:text-primary"
+        : "text-primary font-semibold hover:text-primary/80"
+    }`}
+  >
+    {children}
+  </a>
+);
+
+interface FullPageChatWidgetProps {
+  widgetId: string;
+  theme?: string | null;
+}
+
+export default function FullPageChatWidget({ widgetId, theme: themeId }: FullPageChatWidgetProps) {
+  const widgetTheme = getTheme(themeId);
+
+  const [userName, setUserName] = useState<string>("");
+  const [nameInput, setNameInput] = useState<string>("");
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [inputMessage, setInputMessage] = useState<string>("");
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [selectedFattalRoom, setSelectedFattalRoom] = useState<FattalRoom | null>(null);
+  const [selectedListing, setSelectedListing] = useState<WidgetListing | null>(null);
+  const [currentLang, setCurrentLang] = useState<Language>(widgetTheme.direction === 'rtl' ? 'HE' : 'EN');
+
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const conversationIdRef = useRef<string | null>(null);
+  const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const lastActivityRef = useRef<number>(Date.now());
+  const epochRef = useRef(0);
+  const welcomeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Apply theme CSS custom properties
+  useEffect(() => {
+    const root = document.documentElement;
+    root.style.setProperty('--theme-primary', widgetTheme.colors.primary);
+    root.style.setProperty('--theme-primary-light', widgetTheme.colors.primaryLight);
+    root.style.setProperty('--theme-accent', widgetTheme.colors.accent);
+    root.style.setProperty('--theme-background', widgetTheme.colors.background);
+    root.style.setProperty('--theme-accent-light', widgetTheme.colors.accentLight);
+  }, [widgetTheme]);
+
+  // Auto-scroll to bottom when new messages arrive
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  const stopPolling = useCallback(() => {
+    if (pollingIntervalRef.current) {
+      clearInterval(pollingIntervalRef.current);
+      pollingIntervalRef.current = null;
+    }
+  }, []);
+
+  const startPolling = useCallback((conversationId: string) => {
+    stopPolling();
+    pollingIntervalRef.current = setInterval(async () => {
+      const myEpoch = epochRef.current;
+      if (Date.now() - lastActivityRef.current > INACTIVITY_TIMEOUT_MS) {
+        stopPolling();
+        return;
+      }
+      try {
+        const res = await fetch(`/api/widget/poll?conversationId=${conversationId}`);
+        if (!res.ok) return;
+        if (epochRef.current !== myEpoch) return;
+        const body = await res.json();
+        const data = body.data; // unwrap from { success, data }
+        if (!data?.message && !data?.hotelOptions && !data?.listingOptions && !data?.roomSearchResults) return;
+        if (data.languageCode) setCurrentLang(parseLanguageCode(data.languageCode));
+        setMessages((prev) => [...prev, {
+          id: Date.now().toString() + "-agent",
+          text: data.message ?? "",
+          sender: "bot",
+          timestamp: new Date(),
+          direction: detectTextDirection(data.message ?? ""),
+          hotelOptions: data.hotelOptions ?? undefined,
+          roomSearchResults: data.roomSearchResults ?? undefined,
+          listingOptions: data.listingOptions ?? undefined,
+          contactForm: data.contactForm ?? undefined,
+          languageCode: data.languageCode ?? undefined,
+        }]);
+        setIsLoading(false);
+        lastActivityRef.current = Date.now();
+        setTimeout(() => inputRef.current?.focus(), 0);
+      } catch {
+        // silently ignore polling errors
+      }
+    }, POLLING_INTERVAL_MS);
+  }, [stopPolling]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      stopPolling();
+      if (welcomeTimerRef.current) clearTimeout(welcomeTimerRef.current);
+    };
+  }, [stopPolling]);
+
+  const sendMessageToAPI = useCallback(async (
+    message: string,
+    currentUserName: string,
+    formData?: Record<string, string | boolean>,
+  ) => {
+    if (!conversationIdRef.current) {
+      conversationIdRef.current = crypto.randomUUID();
+      startPolling(conversationIdRef.current);
+    }
+    lastActivityRef.current = Date.now();
+    try {
+      const res = await fetch("/api/widget/messages", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          companyId: widgetId,
+          conversationId: conversationIdRef.current,
+          message,
+          userName: currentUserName,
+          timestamp: new Date().toISOString(),
+          ...(formData ? { formData } : {}),
+        }),
+      });
+      if (!res.ok) {
+        setIsLoading(false);
+      }
+    } catch {
+      setIsLoading(false);
+    }
+  }, [widgetId, startPolling]);
+
+  // Handle name submission
+  const handleNameSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!nameInput.trim()) return;
+
+    setUserName(nameInput.trim());
+
+    const firstWelcomeMessage: Message = {
+      id: Date.now().toString() + "-welcome-1",
+      text: widgetTheme.welcomeMessages.first(nameInput.trim()),
+      sender: "bot",
+      timestamp: new Date(),
+      direction: widgetTheme.welcomeMessages.firstDirection,
+    };
+
+    setMessages([firstWelcomeMessage]);
+
+    if (widgetTheme.welcomeMessages.second) {
+      welcomeTimerRef.current = setTimeout(() => {
+        const secondWelcomeMessage: Message = {
+          id: Date.now().toString() + "-welcome-2",
+          text: widgetTheme.welcomeMessages.second,
+          sender: "bot",
+          timestamp: new Date(),
+          direction: widgetTheme.welcomeMessages.secondDirection,
+        };
+        setMessages((prev) => [...prev, secondWelcomeMessage]);
+      }, 1500);
+    }
+  };
+
+  // Handle message submission
+  const handleMessageSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!inputMessage.trim() || isLoading) return;
+
+    const userMessage: Message = {
+      id: Date.now().toString(),
+      text: inputMessage.trim(),
+      sender: "user",
+      timestamp: new Date(),
+      direction: detectTextDirection(inputMessage),
+    };
+
+    setMessages((prev) => [...prev, userMessage]);
+    const messageText = inputMessage.trim();
+    setInputMessage("");
+    setIsLoading(true);
+
+    setTimeout(() => inputRef.current?.focus(), 0);
+
+    await sendMessageToAPI(messageText, userName);
+    // isLoading stays true until poll receives response
+  };
+
+  // Handle input change
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputMessage(e.target.value);
+  };
+
+  // Handle Enter key press
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleMessageSubmit(e as unknown as React.FormEvent<HTMLFormElement>);
+    }
+  };
+
+  // Reset chat
+  const resetChat = () => {
+    stopPolling();
+    epochRef.current += 1;
+    conversationIdRef.current = null;
+    setUserName("");
+    setMessages([]);
+    setNameInput("");
+    setIsLoading(false);
+    setSelectedFattalRoom(null);
+    setSelectedListing(null);
+  };
+
+  // Handle contact form submission
+  const handleContactFormSubmit = async (formData: Record<string, string | boolean>) => {
+    if (isLoading) return;
+
+    const submittedMessage = t(currentLang, 'contactFormSubmitted');
+    const userMessage: Message = {
+      id: Date.now().toString(),
+      text: submittedMessage,
+      sender: "user",
+      timestamp: new Date(),
+      direction: detectTextDirection(submittedMessage),
+    };
+
+    setMessages((prev) => [...prev, userMessage]);
+    setIsLoading(true);
+
+    await sendMessageToAPI(submittedMessage, userName, formData);
+    // isLoading stays true until poll receives response
+  };
+
+  // Handle hotel selection
+  const handleSelectHotel = async (hotel: FattalHotel) => {
+    if (isLoading) return;
+
+    const userMessage: Message = {
+      id: Date.now().toString(),
+      text: hotel.hotelName,
+      sender: "user",
+      timestamp: new Date(),
+      direction: detectTextDirection(hotel.hotelName),
+    };
+
+    setMessages((prev) => [...prev, userMessage]);
+    setIsLoading(true);
+
+    await sendMessageToAPI(hotel.hotelName, userName);
+    // isLoading stays true until poll receives response
+  };
+
+  const handleSelectFattalRoom = (room: FattalRoom) => { setSelectedFattalRoom(room); };
+  const handleBackFromFattalRoom = () => { setSelectedFattalRoom(null); };
+
+  const handleConfirmFattalRoom = async (
+    room: FattalRoom,
+    selectedPackage: FattalRoomPackage,
+    selectedPrice: FattalPackagePrice,
+    isClubMember: boolean
+  ) => {
+    if (isLoading) return;
+
+    const displayPrice = isClubMember && selectedPrice.clubTotalPrice
+      ? selectedPrice.clubTotalPrice
+      : selectedPrice.totalPrice;
+
+    const selectionMessage = `${t(currentLang, 'bookingIntro')}\n` +
+      `${t(currentLang, 'roomLabel')}: ${room.name}\n` +
+      `${t(currentLang, 'packageLabel')}: ${selectedPackage.packageName}\n` +
+      `${t(currentLang, 'hostingTypeLabel')}: ${selectedPrice.hostingBase}\n` +
+      `${isClubMember ? t(currentLang, 'clubMemberYes') + '\n' : ''}` +
+      `${t(currentLang, 'priceLabel')}: ${formatPriceI18n(displayPrice, currentLang)} ₪`;
+
+    const userMessage: Message = {
+      id: Date.now().toString(),
+      text: selectionMessage,
+      sender: "user",
+      timestamp: new Date(),
+      direction: currentLang === 'HE' ? "rtl" : "ltr",
+    };
+
+    setMessages((prev) => [...prev, userMessage]);
+    setSelectedFattalRoom(null);
+    setIsLoading(true);
+
+    await sendMessageToAPI(selectionMessage, userName);
+    // isLoading stays true until poll receives response
+  };
+
+  const handleViewListingDetails = (listing: WidgetListing) => { setSelectedListing(listing); };
+  const handleBackFromListingDetail = () => { setSelectedListing(null); };
+
+  const handleSelectListing = async (listing: WidgetListing) => {
+    if (isLoading) return;
+
+    const userMessage: Message = {
+      id: Date.now().toString(),
+      text: listing.name,
+      sender: "user",
+      timestamp: new Date(),
+      direction: detectTextDirection(listing.name),
+    };
+
+    setMessages((prev) => [...prev, userMessage]);
+    setSelectedListing(null);
+    setIsLoading(true);
+
+    await sendMessageToAPI(listing.name, userName);
+    // isLoading stays true until poll receives response
+  };
+
+  if (!userName) {
+    return (
+      <div dir={widgetTheme.direction} className="flex flex-col h-screen w-screen overflow-hidden">
+        <div className="bg-primary py-2 px-4 flex items-center gap-3">
+          <Image
+            src={widgetTheme.logoUrl}
+            priority={true}
+            alt="Logo"
+            width={widgetTheme.logoSize.width}
+            height={widgetTheme.logoSize.height}
+            className="object-contain"
+          />
+          <h2 className="text-lg font-bold text-white">
+            {widgetTheme.text.welcomeTitle}
+          </h2>
+        </div>
+
+        <div className="flex-1 flex flex-col items-center justify-center p-6 bg-surface">
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="w-full max-w-md"
+          >
+            <form onSubmit={handleNameSubmit} className="space-y-4">
+              <div>
+                <label htmlFor="name" className="block text-sm font-medium mb-2 text-primary">
+                  {widgetTheme.text.nameLabel}
+                </label>
+                <input
+                  id="name"
+                  type="text"
+                  value={nameInput}
+                  onChange={(e) => setNameInput(e.target.value)}
+                  className="w-full px-4 py-3 border-2 border-primary/20 rounded-xl
+                           bg-white text-primary focus:outline-none focus:border-accent
+                           placeholder:text-primary/50"
+                  placeholder={widgetTheme.text.namePlaceholder}
+                  autoFocus
+                />
+              </div>
+              <motion.button
+                type="submit"
+                whileHover={{ scale: 1.02 }}
+                whileTap={{ scale: 0.98 }}
+                className="w-full bg-accent hover:bg-accent/90 text-white font-semibold py-3 px-4
+                          rounded-xl transition-colors shadow-md"
+              >
+                {widgetTheme.text.startChat}
+              </motion.button>
+            </form>
+          </motion.div>
+        </div>
+
+        <div className="bg-white py-2 px-4 text-center border-t border-primary/10">
+          <p className="text-xs text-primary/60">
+            Powered by{" "}
+            <a
+              href="https://ersona.co"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-accent hover:text-accent/80 transition-colors font-medium"
+            >
+              Ersona
+            </a>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div dir={widgetTheme.direction} className="flex flex-col h-screen w-screen overflow-hidden">
+      <div className="flex items-center justify-between py-2 px-4 bg-primary">
+        <h3 className="font-semibold flex items-center gap-2 text-white text-sm">
+          <Image
+            src={widgetTheme.logoUrl}
+            priority={true}
+            alt="Logo"
+            width={24}
+            height={24}
+            className="object-contain"
+          />
+          <span>{widgetTheme.text.headerTitle}</span>
+        </h3>
+        <button
+          onClick={resetChat}
+          className="text-sm text-white/80 hover:text-white transition-colors"
+        >
+          {widgetTheme.text.resetButton}
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-4 space-y-4 bg-surface">
+        <AnimatePresence>
+          {messages.map((message) => (
+            <div key={message.id}>
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -20 }}
+                className={`flex ${message.sender === "user" ? "justify-end" : "justify-start"}`}
+              >
+                <div
+                  dir={message.direction}
+                  className={`max-w-xs lg:max-w-md px-4 py-3 rounded-2xl shadow-sm ${
+                    message.sender === "user"
+                      ? "bg-accent text-primary"
+                      : "bg-white text-primary border border-primary/10"
+                  }`}
+                >
+                  <div className="text-sm prose prose-sm max-w-none [&>p]:m-0 [&>ul]:m-0 [&>ol]:m-0 [&>p+p]:mt-2 whitespace-pre-wrap">
+                    <Markdown
+                      components={{
+                        a: ({ href, children }) => (
+                          <MarkdownLink href={href} isUserMessage={message.sender === "user"}>
+                            {children}
+                          </MarkdownLink>
+                        ),
+                        strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+                        em: ({ children }) => <em className="italic">{children}</em>,
+                      }}
+                    >
+                      {message.text}
+                    </Markdown>
+                  </div>
+                  <p className={`text-xs mt-2 ${
+                    message.sender === "user" ? "text-primary/60" : "text-primary/50"
+                  }`}>
+                    {message.timestamp.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+                  </p>
+                </div>
+              </motion.div>
+
+              {message.contactForm && (
+                <ContactForm
+                  config={message.contactForm}
+                  lang={currentLang}
+                  onSubmit={handleContactFormSubmit}
+                  disabled={isLoading}
+                />
+              )}
+
+              {message.hotelOptions && message.hotelOptions.length > 0 && (
+                <HotelCarousel hotels={message.hotelOptions} onSelectHotel={handleSelectHotel} lang={currentLang} />
+              )}
+
+              {message.roomSearchResults && message.roomSearchResults.length > 0 && (
+                <>
+                  {selectedFattalRoom ? (
+                    <FattalRoomDetailView
+                      room={selectedFattalRoom}
+                      onConfirm={handleConfirmFattalRoom}
+                      onBack={handleBackFromFattalRoom}
+                      lang={currentLang}
+                    />
+                  ) : (
+                    <FattalRoomCarousel rooms={message.roomSearchResults} onSelectRoom={handleSelectFattalRoom} lang={currentLang} />
+                  )}
+                </>
+              )}
+
+              {message.listingOptions && message.listingOptions.length > 0 && (
+                <>
+                  {selectedListing ? (
+                    <ListingDetailView
+                      listing={selectedListing}
+                      onSelect={handleSelectListing}
+                      onBack={handleBackFromListingDetail}
+                      lang={currentLang}
+                    />
+                  ) : (
+                    <ListingCarousel listings={message.listingOptions} onViewDetails={handleViewListingDetails} lang={currentLang} />
+                  )}
+                </>
+              )}
+            </div>
+          ))}
+          {isLoading && (
+            <motion.div
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.2, ease: "easeOut" }}
+              className="flex justify-start"
+            >
+              <LoadingSpinner />
+            </motion.div>
+          )}
+        </AnimatePresence>
+        <div ref={messagesEndRef} />
+      </div>
+
+      <div className="p-4 bg-white border-t border-primary/10">
+        <form onSubmit={handleMessageSubmit} className="flex gap-2">
+          <input
+            ref={inputRef}
+            type="text"
+            value={inputMessage}
+            onChange={handleInputChange}
+            onKeyDown={handleKeyDown}
+            dir="auto"
+            disabled={isLoading}
+            className="flex-1 px-4 py-3 border-2 border-primary/20 rounded-xl
+                     bg-white text-primary focus:outline-none focus:border-accent
+                     text-sm placeholder:text-primary/40
+                     disabled:opacity-50 disabled:cursor-not-allowed"
+            placeholder={widgetTheme.text.inputPlaceholder}
+          />
+          <motion.button
+            type="submit"
+            disabled={isLoading || !inputMessage.trim()}
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.95 }}
+            className="bg-accent hover:bg-accent/90 text-white font-medium p-3
+                     rounded-xl transition-colors flex items-center justify-center
+                     disabled:opacity-50 disabled:cursor-not-allowed shadow-md"
+          >
+            <LuSendHorizontal className={`w-5 h-5 transition-transform ${widgetTheme.direction === "rtl" ? "rotate-180" : ""}`} />
+          </motion.button>
+        </form>
+      </div>
+
+      <div className="py-2 px-4 bg-white text-center">
+        <p className="text-xs text-primary/50">
+          Powered by:{" "}
+          <a
+            href="https://ersona.co"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent hover:text-accent/80 transition-colors font-medium"
+          >
+            Ersona
+          </a>
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `src/components/FullPageChatWidget.tsx` — full-page chat component that calls `/api/widget/messages` and `/api/widget/poll` directly (no postMessage/iframe relay)
- Adds `src/app/booking/page.tsx` — new route at `/booking?widgetId=<id>&theme=<id>`
- Updates `CLAUDE.md` with CSS variable patterns, theme interface notes, and poll API shape

## How it works

The existing embeddable widget uses an iframe + postMessage relay via `chat-widget.js`. The new `/booking` page is a standalone full-page version that:
- Calls the same existing API routes directly
- Generates `conversationId` via `crypto.randomUUID()` on first message
- Polls `/api/widget/poll` every 2.5s for agent responses
- Includes epoch-based stale-response protection on chat reset

## Test plan

- [ ] Open `http://localhost:3000/booking?widgetId=<real-id>&theme=eztlv` — name form renders
- [ ] Submit name → welcome messages appear
- [ ] Type a message → loading spinner shows, agent response arrives within ~5s
- [ ] Reset chat → conversation clears, new session starts
- [ ] Open without `widgetId` → shows "Missing widgetId parameter" error
- [ ] `npm run build` — no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)