### PR TITLE
feat(widget): visual redesign + configurable themes + Mode B widget config + gallery merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ vite.config.ts.timestamp-*
 
 # Idea
 .idea
+
+# Local-only planning docs
+docs/superpowers/

--- a/public/chat-widget.js
+++ b/public/chat-widget.js
@@ -10,12 +10,14 @@
   // === MESSAGING INTEGRATION BLOCK START ===
   // Find the widget script tag.
   // Preferred: <script id="ersona-chat-widget" data-widget-id="...">
-  // Fallback: any <script> with data-widget-id on it.
+  // Fallback: any <script> with data-widget-id (or legacy data-company-id) on it.
   const widgetScript = document.getElementById('ersona-chat-widget')
-                       || document.querySelector('script[data-widget-id]');
+                       || document.querySelector('script[data-widget-id]')
+                       || document.querySelector('script[data-company-id]');
   const ds = (widgetScript && widgetScript.dataset) || {};
 
-  const widgetId = ds.widgetId || 'default';
+  // Accept data-widget-id (preferred) or legacy data-company-id (same value either way).
+  const widgetId = ds.widgetId || ds.companyId || 'default';
   const widgetLanguage = ds.language || null;
 
   // Session management - always start fresh

--- a/public/chat-widget.js
+++ b/public/chat-widget.js
@@ -8,50 +8,15 @@
   window.ChatWidgetInitialized = true;
 
   // === MESSAGING INTEGRATION BLOCK START ===
-  // Extract companyId from script element (multiple methods for reliability)
-  const getCompanyId = () => {
-    // Method 1: Try to get by ID (most reliable)
-    const widgetScript = document.getElementById('ersona-chat-widget');
-    if (widgetScript && widgetScript.dataset.companyId) {
-      return widgetScript.dataset.companyId;
-    }
-    
-    // Method 2: Try to find any script with data attribute
-    const anyWidgetScript = document.querySelector('script[data-company-id]');
-    if (anyWidgetScript) {
-      return anyWidgetScript.dataset.companyId;
-    }
-    
-    return 'default';
-  };
+  // Find the widget script tag.
+  // Preferred: <script id="ersona-chat-widget" data-widget-id="...">
+  // Fallback: any <script> with data-widget-id on it.
+  const widgetScript = document.getElementById('ersona-chat-widget')
+                       || document.querySelector('script[data-widget-id]');
+  const ds = (widgetScript && widgetScript.dataset) || {};
 
-  const getTheme = () => {
-    const widgetScript = document.getElementById('ersona-chat-widget');
-    if (widgetScript && widgetScript.dataset.theme) {
-      return widgetScript.dataset.theme;
-    }
-
-    const anyWidgetScript = document.querySelector('script[data-theme]');
-    if (anyWidgetScript) {
-      return anyWidgetScript.dataset.theme;
-    }
-
-    return null;
-  };
-
-  const getLanguage = () => {
-    const widgetScript = document.getElementById('ersona-chat-widget');
-    if (widgetScript && widgetScript.dataset.language) {
-      return widgetScript.dataset.language;
-    }
-
-    const anyWidgetScript = document.querySelector('script[data-language]');
-    if (anyWidgetScript) {
-      return anyWidgetScript.dataset.language;
-    }
-
-    return null;
-  };
+  const widgetId = ds.widgetId || 'default';
+  const widgetLanguage = ds.language || null;
 
   // Session management - always start fresh
   const clearSessionOnLoad = () => {
@@ -104,17 +69,10 @@
     resetInactivityTimer();
   };
 
-  const companyId = getCompanyId();
-  const widgetTheme = getTheme();
-  const widgetLanguage = getLanguage();
-
-  // Theme color map for widget button styling (mirrors theme-config.ts)
-  const themeColors = {
-    default: { primary: '#1A3A5C', primaryLight: '#244E75' },
-    fattal:  { primary: '#1d2b4d', primaryLight: '#2d3f66' },
-    eztlv:   { primary: '#2D6DA4', primaryLight: '#3A85C4' },
-  };
-  const buttonColors = themeColors[widgetTheme] || themeColors.default;
+  // Floating button color — neutral by design.
+  // The widget itself themes from MongoDB once opened; the host-page button stays neutral
+  // to avoid an extra HTTP request on every page load just to color a 60px circle.
+  const buttonColors = { primary: '#1A3A5C', primaryLight: '#244E75' };
 
   // Message type constants
   const MESSAGE_TYPES = {
@@ -181,7 +139,7 @@
 
     const postUrl = `${widgetServiceBaseUrl}/api/widget/messages`;
     const payload = {
-      companyId,
+      widgetId,
       conversationId,
       message,
       userName,
@@ -315,8 +273,8 @@
       position: fixed;
       bottom: 90px;
       right: 20px;
-      width: 350px;
-      height: 500px;
+      width: 380px;
+      height: 640px;
       border: 1px solid rgba(0, 0, 0, 1);
       border-radius: 16px;
       box-shadow: 0 8px 12px rgba(0, 0, 0, 0.2);
@@ -420,11 +378,12 @@
   iframe.setAttribute("frameBorder", "0");
   iframe.style.colorScheme = "light";
   iframe.style.background = "transparent";
-  const iframeQuery = [
-    widgetTheme ? "theme=" + encodeURIComponent(widgetTheme) : null,
-    widgetLanguage ? "lang=" + encodeURIComponent(widgetLanguage) : null,
-  ].filter(Boolean).join("&");
-  iframe.src = widgetServiceBaseUrl + "/embed-chat" + (iframeQuery ? "?" + iframeQuery : "");
+  const iframeParams = new URLSearchParams();
+  if (widgetId) iframeParams.set('widgetId', widgetId);
+  const langValue = widgetLanguage;
+  if (langValue) iframeParams.set('lang', langValue);
+  const iframeQuery = iframeParams.toString();
+  iframe.src = widgetServiceBaseUrl + '/embed-chat' + (iframeQuery ? '?' + iframeQuery : '');
 
   // State management
   let isOpen = false;

--- a/public/demo.html
+++ b/public/demo.html
@@ -222,7 +222,7 @@
         });
     </script>
 
-    <!-- Your chat widget script with companyId (using ID + data attribute method) -->
-    <script id="ersona-chat-widget" src="http://localhost:3000/chat-widget.js" data-company-id="widget_vllp2brjc"></script>
+    <!-- Your chat widget script with widgetId (using ID + data attribute method) -->
+    <script id="ersona-chat-widget" src="http://localhost:3000/chat-widget.js" data-widget-id="widget_e97rt12sf"></script>
 </body>
 </html> 

--- a/src/app/actions/widget-actions.ts
+++ b/src/app/actions/widget-actions.ts
@@ -3,7 +3,7 @@
 import { queueFallbackMessage } from '@/services/message-queue-service';
 
 export interface WidgetMessageData {
-  companyId: string;
+  widgetId: string;
   conversationId: string;
   message: string;
   userName: string;
@@ -26,18 +26,18 @@ export interface WidgetActionResult {
 export async function sendToEmbeddingsService(data: WidgetMessageData): Promise<WidgetActionResult> {
   try {
     const embeddingsServiceUrl = process.env.EMBEDDINGS_SERVICE_URL;
-    
+
     if (!embeddingsServiceUrl) {
       throw new Error('EMBEDDINGS SERVICE URL is not set');
     }
-    
+
     const response = await fetch(`${embeddingsServiceUrl}/widget/message`, {
       method: 'POST',
-      headers: { 
+      headers: {
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({
-        companyId: data.companyId,
+        companyId: data.widgetId,
         conversationId: data.conversationId,
         message: data.message,
         userName: data.userName,
@@ -69,24 +69,24 @@ export async function sendToEmbeddingsService(data: WidgetMessageData): Promise<
 
 // Server Action: Main widget message processing
 export async function processWidgetMessage(data: WidgetMessageData): Promise<WidgetActionResult> {
-  const { companyId, conversationId, message, userName } = data;
-  
+  const { widgetId, conversationId, message, userName } = data;
+
   // Validate required fields
-  if (!companyId || !conversationId || !message || !userName) {
+  if (!widgetId || !conversationId || !message || !userName) {
     return {
       success: false,
-      error: 'Missing required fields: companyId, conversationId, message, userName',
+      error: 'Missing required fields: widgetId, conversationId, message, userName',
       timestamp: new Date().toISOString(),
     };
   }
 
   // Send to embeddings service
   const embeddingsResult = await sendToEmbeddingsService(data);
-  
+
   // If embeddings service fails, queue fallback message
   if (!embeddingsResult.success) {
     try {
-      await queueFallbackMessage(companyId, conversationId);
+      await queueFallbackMessage(conversationId);
       return {
         success: true,
         message: 'Message processing failed, but fallback message queued',

--- a/src/app/actions/widget-response-actions.ts
+++ b/src/app/actions/widget-response-actions.ts
@@ -5,7 +5,7 @@ import { type WidgetActionResult } from './widget-actions';
 import { FattalHotel, FattalRoom, WidgetListing } from '@/types/message-types';
 
 export interface WidgetResponseData {
-  companyId: string;
+  widgetId: string;
   conversationId: string;
   message?: string;
   timestamp?: string;
@@ -19,12 +19,12 @@ export interface WidgetResponseData {
 }
 
 export async function processWidgetResponse(data: WidgetResponseData): Promise<WidgetActionResult> {
-  const { companyId, conversationId, message, timestamp, error, hotelOptions, roomSearchResults, listingOptions, formId, formData, languageCode } = data;
+  const { widgetId, conversationId, message, timestamp, error, hotelOptions, roomSearchResults, listingOptions, formId, formData, languageCode } = data;
 
-  if (!companyId || !conversationId) {
+  if (!widgetId || !conversationId) {
     return {
       success: false,
-      error: 'Missing required fields: companyId, conversationId',
+      error: 'Missing required fields: widgetId, conversationId',
       timestamp: new Date().toISOString(),
     };
   }
@@ -42,7 +42,7 @@ export async function processWidgetResponse(data: WidgetResponseData): Promise<W
   }
 
   try {
-    await queueAgentMessage(companyId, conversationId, responseMessage, timestamp, hotelOptions, roomSearchResults, formId, formData, languageCode, listingOptions);
+    await queueAgentMessage(conversationId, responseMessage, timestamp, hotelOptions, roomSearchResults, formId, formData, languageCode, listingOptions);
 
     return {
       success: true,

--- a/src/app/api/widget/checkout/route.ts
+++ b/src/app/api/widget/checkout/route.ts
@@ -5,12 +5,12 @@ import { corsHeaders } from '@/utils/cors';
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { companyId, conversationId, signature, quantity } = body;
+    const { widgetId, conversationId, signature, quantity } = body;
 
     // Validate required fields
-    if (!companyId || !conversationId || !signature || !quantity) {
+    if (!widgetId || !conversationId || !signature || !quantity) {
       return NextResponse.json(
-        { error: 'Missing required fields: companyId, conversationId, signature, quantity' },
+        { error: 'Missing required fields: widgetId, conversationId, signature, quantity' },
         { status: StatusCodes.BAD_REQUEST, headers: corsHeaders }
       );
     }
@@ -38,7 +38,7 @@ export async function POST(request: NextRequest) {
     console.log('Calling checkout endpoint:', checkoutUrl);
     console.log('Request body:', {
       sessionId: conversationId,
-      widgetId: companyId,
+      widgetId,
       signature,
       quantity
     });
@@ -50,7 +50,7 @@ export async function POST(request: NextRequest) {
       },
       body: JSON.stringify({
         sessionId: conversationId,
-        widgetId: companyId,
+        widgetId,
         signature,
         quantity,
       }),

--- a/src/app/api/widget/messages/route.ts
+++ b/src/app/api/widget/messages/route.ts
@@ -9,11 +9,11 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     console.log(JSON.stringify(body));
 
-    const { companyId, conversationId, message, userName, timestamp, meta, formData } = body;
+    const { widgetId, conversationId, message, userName, timestamp, meta, formData } = body;
 
     // Prepare data for server action
     const widgetData: WidgetMessageData = {
-      companyId,
+      widgetId,
       conversationId,
       message,
       userName,

--- a/src/app/api/widget/response/route.ts
+++ b/src/app/api/widget/response/route.ts
@@ -6,11 +6,10 @@ import { processWidgetResponse, type WidgetResponseData } from '@/app/actions/wi
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-
-    const { companyId, conversationId, message, timestamp, error, hotelOptions, roomSearchResults, listingOptions, formId, formData, languageCode } = body;
+    const { companyId: widgetId, conversationId, message, timestamp, error, hotelOptions, roomSearchResults, listingOptions, formId, formData, languageCode } = body;
     // Prepare data for server action
     const responseData: WidgetResponseData = {
-      companyId,
+      widgetId,
       conversationId,
       message,
       timestamp,

--- a/src/app/booking/page.tsx
+++ b/src/app/booking/page.tsx
@@ -1,39 +1,59 @@
-"use client";
+'use client';
 
-import { Suspense } from "react";
-import { useSearchParams } from "next/navigation";
-import FullPageChatWidget from "@/components/FullPageChatWidget";
+import { Suspense, useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import FullPageChatWidget from '@/components/FullPageChatWidget';
+import { resolveWidgetConfig } from '@/config/resolve-widget-config';
+import type { WidgetConfig } from '@/config/widget-config';
 
 function BookingContent() {
   const searchParams = useSearchParams();
-  const widgetId = searchParams.get("widgetId") ?? "";
-  const theme = searchParams.get("theme");
-  const lang = searchParams.get("lang");
+  const [config, setConfig] = useState<WidgetConfig | null>(null);
+  const langOverride = searchParams.get('lang');
 
-  if (!widgetId) {
+  const widgetIdParam = searchParams.get('widgetId');
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!widgetIdParam) return;
+    resolveWidgetConfig(new URLSearchParams(searchParams.toString()))
+      .then((c) => {
+        if (!cancelled) setConfig(c);
+      })
+      .catch((error) => {
+        console.error('[booking] Resolver threw unexpectedly', error);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [searchParams, widgetIdParam]);
+
+  if (!widgetIdParam) {
     return (
-      <div className="h-dvh w-screen flex items-center justify-center bg-gray-50">
-        <p className="text-gray-500 text-sm">Missing widgetId parameter.</p>
+      <div className="h-dvh w-screen flex items-center justify-center bg-background">
+        <p className="text-text/60 text-sm">Missing widgetId parameter.</p>
+      </div>
+    );
+  }
+
+  if (!config) {
+    return (
+      <div className="h-dvh w-full flex items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
       </div>
     );
   }
 
   return (
     <div className="h-dvh w-screen overflow-hidden">
-      <FullPageChatWidget widgetId={widgetId} theme={theme} lang={lang} />
+      <FullPageChatWidget config={config} langOverride={langOverride} />
     </div>
   );
 }
 
 export default function BookingPage() {
   return (
-    <Suspense
-      fallback={
-        <div className="h-dvh w-full flex items-center justify-center">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-fattalNavy" />
-        </div>
-      }
-    >
+    <Suspense fallback={null}>
       <BookingContent />
     </Suspense>
   );

--- a/src/app/embed-chat/page.tsx
+++ b/src/app/embed-chat/page.tsx
@@ -1,30 +1,48 @@
-"use client";
+'use client';
 
-import { Suspense } from "react";
-import { useSearchParams } from "next/navigation";
-import ChatWidget from "@/components/ChatWidget";
+import { Suspense, useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import ChatWidget from '@/components/ChatWidget';
+import { resolveWidgetConfig } from '@/config/resolve-widget-config';
+import type { WidgetConfig } from '@/config/widget-config';
 
 function EmbedChatContent() {
   const searchParams = useSearchParams();
-  const theme = searchParams.get("theme");
-  const lang = searchParams.get("lang");
+  const [config, setConfig] = useState<WidgetConfig | null>(null);
+  const langOverride = searchParams.get('lang');
+
+  useEffect(() => {
+    let cancelled = false;
+    resolveWidgetConfig(new URLSearchParams(searchParams.toString()))
+      .then((c) => {
+        if (!cancelled) setConfig(c);
+      })
+      .catch((error) => {
+        console.error('[embed-chat] Resolver threw unexpectedly', error);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [searchParams]);
+
+  if (!config) {
+    return (
+      <div className="h-screen w-full flex items-center justify-center bg-transparent">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+      </div>
+    );
+  }
 
   return (
     <div className="h-screen w-screen overflow-hidden bg-transparent">
-      <ChatWidget theme={theme} lang={lang} />
+      <ChatWidget config={config} langOverride={langOverride} />
     </div>
   );
 }
 
 export default function EmbedChatPage() {
   return (
-    <Suspense
-      fallback={
-        <div className="h-screen w-full flex items-center justify-center">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
-        </div>
-      }
-    >
+    <Suspense fallback={null}>
       <EmbedChatContent />
     </Suspense>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,22 +6,30 @@
   --foreground: #171717;
 
   /* Theme color tokens (overridden at runtime per theme) */
-  --theme-primary: #1A3A5C;
-  --theme-primary-light: #244E75;
-  --theme-accent: #2685CB;
-  --theme-background: #FFFFFF;
-  --theme-accent-light: #EBF5FF;
+  --theme-primary: #0F2747;
+  --theme-primary-light: #274C77;
+  --theme-secondary: #274C77;
+  --theme-accent: #D6A85F;
+  --theme-accent-light: #F2E5CC;
+  --theme-background: #F8F7F3;
+  --theme-surface: #FFFFFF;
+  --theme-text: #0E1726;
+  --theme-border: #D9E1EA;
+  --theme-bg-treatment: linear-gradient(135deg, #0F2747 0%, #1A3A5C 60%, #274C77 100%);
 }
 
 @theme inline {
   --color-primary: var(--theme-primary);
+  --color-primary-light: var(--theme-primary-light);
+  --color-secondary: var(--theme-secondary);
   --color-accent: var(--theme-accent);
-  --color-surface: var(--theme-background);
+  --color-accent-light: var(--theme-accent-light);
+  --color-surface: var(--theme-surface);
+  --color-text: var(--theme-text);
+  --color-border: var(--theme-border);
+  /* Legacy aliases preserved for backward compatibility */
   --color-accentLight: var(--theme-accent-light);
   --color-primaryLight: var(--theme-primary-light);
-}
-
-@theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -1,0 +1,538 @@
+'use client';
+
+import { Suspense, useState, useCallback, useEffect, FormEvent } from 'react';
+import { useRouter, usePathname, useSearchParams } from 'next/navigation';
+
+import { themes, getTheme } from '@/config/theme-config';
+import { resolveWidgetConfig } from '@/config/resolve-widget-config';
+import type { Language } from '@/utils/i18n';
+import type { QuickActionId, WidgetConfig } from '@/config/widget-config';
+
+import WidgetShell from '@/components/shell/WidgetShell';
+import WelcomeScreen from '@/components/shell/WelcomeScreen';
+import ChatHeader from '@/components/shell/ChatHeader';
+import MessageBubble from '@/components/shell/MessageBubble';
+import Composer from '@/components/shell/Composer';
+import LanguageSelector from '@/components/shell/LanguageSelector';
+import QuickActions from '@/components/shell/QuickActions';
+
+// ---------------------------------------------------------------------------
+// Sample data
+// ---------------------------------------------------------------------------
+
+const SAMPLE_BG_URL =
+  'https://images.unsplash.com/photo-1566073771259-6a8506099945?w=1200';
+
+const SAMPLE_HOTEL_NAME = 'Hotel Ben-Yamin';
+
+interface SampleMsg {
+  id: string;
+  sender: 'bot' | 'user';
+  he: string;
+  en: string;
+  timestamp: Date;
+}
+
+const BASE_TIME = new Date('2025-01-01T10:00:00');
+const t1 = new Date(BASE_TIME.getTime() + 0 * 60_000);
+const t2 = new Date(BASE_TIME.getTime() + 1 * 60_000);
+const t3 = new Date(BASE_TIME.getTime() + 2 * 60_000);
+
+const SAMPLE_MESSAGES: SampleMsg[] = [
+  {
+    id: '1',
+    sender: 'bot',
+    he: 'היי יוסי, ברוכים הבאים! איך נוכל לעזור לך היום?',
+    en: 'Hi Yossi, welcome! How can we help you today?',
+    timestamp: t1,
+  },
+  {
+    id: '2',
+    sender: 'user',
+    he: 'אשמח לבצע הזמנה',
+    en: "I'd like to make a reservation",
+    timestamp: t2,
+  },
+  {
+    id: '3',
+    sender: 'bot',
+    he: 'שלום יוסי! אשמח לעזור לך למצוא את האפשרות המתאימה. כדי שנתחיל, אשמח לדעת:\n1. אילו תאריכים תרצה?\n2. לכמה אורחים?\n3. באיזו חבילה אתה מעוניין?',
+    en: "Hi Yossi! I'd be happy to help you find the right option. To get started, I'd like to know:\n1. What dates are you looking for?\n2. How many guests?\n3. What package are you interested in?",
+    timestamp: t3,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Toolbar
+// ---------------------------------------------------------------------------
+
+interface ToolbarProps {
+  themeId: string;
+  lang: Language;
+  screen: 'welcome' | 'chat';
+  hasHotelName: boolean;
+  hasBg: boolean;
+  onThemeChange: (v: string) => void;
+  onLangChange: (v: Language) => void;
+  onScreenChange: (v: 'welcome' | 'chat') => void;
+  onHotelNameToggle: (v: boolean) => void;
+  onBgToggle: (v: boolean) => void;
+}
+
+function Toolbar({
+  themeId,
+  lang,
+  screen,
+  hasHotelName,
+  hasBg,
+  onThemeChange,
+  onLangChange,
+  onScreenChange,
+  onHotelNameToggle,
+  onBgToggle,
+}: ToolbarProps) {
+  const selectBase =
+    'px-2 py-1.5 rounded-md border border-gray-300 bg-white text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400';
+  const btnBase =
+    'px-3 py-1.5 rounded-md text-sm font-medium border transition-colors';
+  const btnActive = 'bg-blue-600 text-white border-blue-600';
+  const btnInactive = 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50';
+  const labelBase = 'flex items-center gap-1.5 text-sm text-gray-700 cursor-pointer select-none';
+
+  return (
+    <div
+      style={{ background: '#f3f4f6', borderBottom: '1px solid #d1d5db' }}
+      className="px-4 py-2.5 flex flex-wrap items-center gap-3"
+    >
+      {/* Theme */}
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+          Theme
+        </span>
+        <select
+          value={themeId}
+          onChange={(e) => onThemeChange(e.target.value)}
+          className={selectBase}
+        >
+          {Object.values(themes).map((t) => (
+            <option key={t.id} value={t.id}>
+              {t.displayName}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Divider */}
+      <span className="w-px h-5 bg-gray-300" />
+
+      {/* Language */}
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+          Lang
+        </span>
+        <div className="flex rounded-md overflow-hidden border border-gray-300">
+          {(['HE', 'EN'] as Language[]).map((l) => (
+            <button
+              key={l}
+              type="button"
+              onClick={() => onLangChange(l)}
+              className={`${btnBase} rounded-none border-0 border-r last:border-r-0 border-gray-300 ${
+                lang === l ? btnActive : btnInactive
+              }`}
+            >
+              {l}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Divider */}
+      <span className="w-px h-5 bg-gray-300" />
+
+      {/* Screen toggle */}
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+          Screen
+        </span>
+        <div className="flex rounded-md overflow-hidden border border-gray-300">
+          {(['welcome', 'chat'] as const).map((s) => (
+            <button
+              key={s}
+              type="button"
+              onClick={() => onScreenChange(s)}
+              className={`${btnBase} rounded-none border-0 border-r last:border-r-0 border-gray-300 ${
+                screen === s ? btnActive : btnInactive
+              }`}
+            >
+              {s.charAt(0).toUpperCase() + s.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Divider */}
+      <span className="w-px h-5 bg-gray-300" />
+
+      {/* Hotel name toggle */}
+      <label className={labelBase}>
+        <input
+          type="checkbox"
+          checked={hasHotelName}
+          onChange={(e) => onHotelNameToggle(e.target.checked)}
+          className="w-4 h-4 accent-blue-600"
+        />
+        <span>Hotel name</span>
+      </label>
+
+      {/* BG image toggle */}
+      <label className={labelBase}>
+        <input
+          type="checkbox"
+          checked={hasBg}
+          onChange={(e) => onBgToggle(e.target.checked)}
+          className="w-4 h-4 accent-blue-600"
+        />
+        <span>BG image</span>
+      </label>
+
+      {/* Info badge */}
+      <span className="ms-auto text-[10px] text-gray-400 font-mono hidden sm:inline">
+        /preview — dev only
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Welcome preview
+// ---------------------------------------------------------------------------
+
+interface WelcomePreviewProps {
+  config: WidgetConfig;
+  lang: Language;
+  onLangChange: (l: Language) => void;
+}
+
+function WelcomePreview({ config, lang, onLangChange }: WelcomePreviewProps) {
+  const [nameInput, setNameInput] = useState('');
+  const theme = getTheme(config.selectedTheme);
+  const direction = lang === 'HE' ? 'rtl' : 'ltr';
+
+  const handleStart = useCallback(
+    (e: FormEvent) => {
+      e.preventDefault();
+      console.log('[preview] start with name:', nameInput);
+    },
+    [nameInput]
+  );
+
+  const handleQuickAction = useCallback((id: QuickActionId) => {
+    console.log('[preview] quick action:', id);
+  }, []);
+
+  const langSelector = config.showLanguageSelector ? (
+    <LanguageSelector
+      current={lang}
+      enabled={config.enabledLanguages}
+      onChange={onLangChange}
+    />
+  ) : undefined;
+
+  return (
+    <WidgetShell
+      theme={theme}
+      showBackground
+      backgroundImageUrl={config.backgroundImageUrl}
+      direction={direction}
+    >
+      <WelcomeScreen
+        theme={theme}
+        hotelName={config.hotelName}
+        logoUrl={config.logoUrl}
+        lang={lang}
+        nameInput={nameInput}
+        onNameInputChange={setNameInput}
+        onStart={handleStart}
+        quickActionsEnabled={config.quickActionsEnabled}
+        enabledQuickActions={config.enabledQuickActions}
+        onQuickAction={handleQuickAction}
+        rightSlot={langSelector}
+      />
+    </WidgetShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Chat preview
+// ---------------------------------------------------------------------------
+
+interface ChatPreviewProps {
+  config: WidgetConfig;
+  lang: Language;
+  onLangChange: (l: Language) => void;
+}
+
+function ChatPreview({ config, lang, onLangChange }: ChatPreviewProps) {
+  const [composerValue, setComposerValue] = useState('');
+  const theme = getTheme(config.selectedTheme);
+  const direction = lang === 'HE' ? 'rtl' : 'ltr';
+
+  const handleSubmit = useCallback(() => {
+    console.log('[preview] send message:', composerValue);
+    setComposerValue('');
+  }, [composerValue]);
+
+  const handleQuickAction = useCallback((id: QuickActionId) => {
+    console.log('[preview] chat quick action:', id);
+  }, []);
+
+  const langSelector = config.showLanguageSelector ? (
+    <LanguageSelector
+      current={lang}
+      enabled={config.enabledLanguages}
+      onChange={onLangChange}
+    />
+  ) : undefined;
+
+  return (
+    <WidgetShell
+      theme={theme}
+      showBackground={false}
+      backgroundImageUrl={null}
+      direction={direction}
+    >
+      <ChatHeader
+        theme={theme}
+        hotelName={config.hotelName}
+        logoUrl={config.logoUrl}
+        lang={lang}
+        onReset={() => console.log('[preview] reset')}
+        rightSlot={langSelector}
+      />
+
+      {/* Message list */}
+      <div className="flex-1 overflow-y-auto px-3 py-4 space-y-4 bg-background">
+        {SAMPLE_MESSAGES.map((msg) => (
+          <MessageBubble
+            key={msg.id}
+            sender={msg.sender}
+            text={lang === 'HE' ? msg.he : msg.en}
+            timestamp={msg.timestamp}
+            direction={msg.sender === 'user' ? direction : lang === 'HE' ? 'rtl' : 'ltr'}
+          />
+        ))}
+      </div>
+
+      {/* Composer with suggestion chips */}
+      <Composer
+        value={composerValue}
+        onChange={setComposerValue}
+        onSubmit={handleSubmit}
+        placeholder={theme.text[lang].inputPlaceholder}
+        direction={direction}
+        formLabel={lang === 'HE' ? 'כתיבת הודעה' : 'Message composer'}
+        chipsSlot={
+          config.quickActionsEnabled && config.enabledQuickActions.length > 0 ? (
+            <QuickActions
+              enabled={config.enabledQuickActions}
+              lang={lang}
+              variant="chat"
+              onSelect={handleQuickAction}
+            />
+          ) : undefined
+        }
+      />
+    </WidgetShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Simulator container
+// ---------------------------------------------------------------------------
+
+function SimulatorContainer({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flex: 1,
+        padding: '24px 16px',
+        background: '#e5e7eb',
+      }}
+    >
+      {/* On mobile: stretch full width. On desktop: fixed 400×700. */}
+      <div
+        style={{
+          width: 'min(400px, 100%)',
+          height: '700px',
+          border: '1px solid #d1d5db',
+          borderRadius: '12px',
+          overflow: 'hidden',
+          boxShadow:
+            '0 20px 25px -5px rgba(0,0,0,0.15), 0 8px 10px -6px rgba(0,0,0,0.1)',
+          position: 'relative',
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Core preview content (reads search params)
+// ---------------------------------------------------------------------------
+
+function PreviewContent() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  // Derive current values from URL
+  const themeId = searchParams.get('theme') || 'urban';
+  const urlLang = (searchParams.get('lang') || 'HE').toUpperCase() as Language;
+  const screen = (searchParams.get('screen') || 'welcome') as 'welcome' | 'chat';
+  const hasHotelName = searchParams.get('hotelName') !== null;
+  const hasBg = searchParams.get('bgUrl') !== null;
+
+  // Local language state so LanguageSelector updates are instant (no full
+  // page reload), while also being URL-sync'd as secondary truth.
+  const [lang, setLang] = useState<Language>(urlLang);
+
+  // Build a resolved config from current URL params (async fetch from chat service)
+  const [config, setConfig] = useState<WidgetConfig | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    resolveWidgetConfig(new URLSearchParams(searchParams.toString()))
+      .then((c) => { if (!cancelled) setConfig(c); })
+      .catch((err) => console.error('[preview] resolveWidgetConfig error', err));
+    return () => { cancelled = true; };
+  }, [searchParams]);
+
+  // ---------------------------------------------------------------------------
+  // URL update helpers
+  // ---------------------------------------------------------------------------
+
+  const updateParam = useCallback(
+    (key: string, value: string | null) => {
+      const next = new URLSearchParams(searchParams.toString());
+      if (value === null) {
+        next.delete(key);
+      } else {
+        next.set(key, value);
+      }
+      router.replace(`${pathname}?${next.toString()}`, { scroll: false });
+    },
+    [router, pathname, searchParams]
+  );
+
+  const handleThemeChange = useCallback(
+    (v: string) => updateParam('theme', v),
+    [updateParam]
+  );
+
+  const handleLangChange = useCallback(
+    (v: Language) => {
+      setLang(v);
+      updateParam('lang', v);
+    },
+    [updateParam]
+  );
+
+  const handleScreenChange = useCallback(
+    (v: 'welcome' | 'chat') => updateParam('screen', v),
+    [updateParam]
+  );
+
+  const handleHotelNameToggle = useCallback(
+    (checked: boolean) =>
+      updateParam('hotelName', checked ? SAMPLE_HOTEL_NAME : null),
+    [updateParam]
+  );
+
+  const handleBgToggle = useCallback(
+    (checked: boolean) => updateParam('bgUrl', checked ? SAMPLE_BG_URL : null),
+    [updateParam]
+  );
+
+  // Sync local lang if URL lang changes (e.g. browser back/forward)
+  // We compare against urlLang which is derived each render.
+  if (lang !== urlLang && !['welcome', 'chat'].includes(lang as string)) {
+    // fallback guard — no-op branch, handled by state initialisation
+  }
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100vh',
+        overflow: 'hidden',
+        background: '#e5e7eb',
+      }}
+    >
+      <Toolbar
+        themeId={themeId}
+        lang={lang}
+        screen={screen}
+        hasHotelName={hasHotelName}
+        hasBg={hasBg}
+        onThemeChange={handleThemeChange}
+        onLangChange={handleLangChange}
+        onScreenChange={handleScreenChange}
+        onHotelNameToggle={handleHotelNameToggle}
+        onBgToggle={handleBgToggle}
+      />
+
+      <SimulatorContainer>
+        {!config ? (
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+          </div>
+        ) : screen === 'welcome' ? (
+          <WelcomePreview
+            config={config}
+            lang={lang}
+            onLangChange={handleLangChange}
+          />
+        ) : (
+          <ChatPreview
+            config={config}
+            lang={lang}
+            onLangChange={handleLangChange}
+          />
+        )}
+      </SimulatorContainer>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page export (with Suspense boundary for useSearchParams)
+// ---------------------------------------------------------------------------
+
+export default function PreviewPage() {
+  return (
+    <Suspense
+      fallback={
+        <div
+          style={{
+            height: '100vh',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: '#e5e7eb',
+            color: '#6b7280',
+            fontFamily: 'system-ui, sans-serif',
+          }}
+        >
+          Loading preview...
+        </div>
+      }
+    >
+      <PreviewContent />
+    </Suspense>
+  );
+}

--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -2,11 +2,16 @@
 
 import { useState, useEffect, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { LuSendHorizontal } from "react-icons/lu";
-import Image from "next/image";
-import Markdown from "react-markdown";
 import LoadingSpinner from "./LoadingSpinner";
-import { ChatWidgetMessageType, FattalHotel, FattalRoom, FattalRoomPackage, FattalPackagePrice, WidgetListing, WidgetFormId } from "@/types/message-types";
+import {
+  ChatWidgetMessageType,
+  FattalHotel,
+  FattalRoom,
+  FattalRoomPackage,
+  FattalPackagePrice,
+  WidgetListing,
+  WidgetFormId,
+} from "@/types/message-types";
 import HotelCarousel from "./HotelCarousel";
 import FattalRoomCarousel from "./FattalRoomCarousel";
 import FattalRoomDetailView from "./FattalRoomDetailView";
@@ -18,8 +23,23 @@ import FattalIdCollectForm from "./FattalIdCollectForm";
 import FattalOtpVerifyForm from "./FattalOtpVerifyForm";
 import FattalCancellationForm from "./FattalCancellationForm";
 import FattalContactUpdateForm from "./FattalContactUpdateForm";
-import { Language, t, formatPrice as formatPriceI18n, parseLanguageCode } from "@/utils/i18n";
+import {
+  Language,
+  t,
+  formatPrice as formatPriceI18n,
+  parseLanguageCode,
+} from "@/utils/i18n";
 import { getTheme } from "@/config/theme-config";
+import type { WidgetConfig, QuickActionId } from "@/config/widget-config";
+import { getQuickActionPrompt } from "@/config/quick-actions";
+
+// Shell components
+import WidgetShell from "./shell/WidgetShell";
+import WelcomeScreen from "./shell/WelcomeScreen";
+import ChatHeader from "./shell/ChatHeader";
+import MessageBubble from "./shell/MessageBubble";
+import Composer from "./shell/Composer";
+import LanguageSelector from "./shell/LanguageSelector";
 
 interface Message {
   id: string;
@@ -36,68 +56,48 @@ interface Message {
 }
 
 // Hebrew character detection regex
-const HEBREW_REGEX = /[\u0590-\u05FF]/;
+const HEBREW_REGEX = /[֐-׿]/;
 
 const detectTextDirection = (text: string): "ltr" | "rtl" => {
   return HEBREW_REGEX.test(text.charAt(0)) ? "rtl" : "ltr";
 };
 
-// Custom link component for Markdown
-const MarkdownLink = ({ href, children, isUserMessage }: { href?: string; children: React.ReactNode; isUserMessage: boolean }) => (
-  <a
-    href={href}
-    target="_blank"
-    rel="noopener noreferrer"
-    className={`underline hover:no-underline transition-colors font-medium ${
-      isUserMessage
-        ? "text-primary/80 hover:text-primary"
-        : "text-primary font-semibold hover:text-primary/80"
-    }`}
-  >
-    {children}
-  </a>
-);
-
 interface ChatWidgetProps {
-  theme?: string | null;
-  lang?: string | null;
+  config: WidgetConfig;
+  langOverride?: string | null;
 }
 
-export default function ChatWidget({ theme: themeId, lang: langProp }: ChatWidgetProps) {
-  const widgetTheme = getTheme(themeId);
-  const initialLang: Language = langProp
-    ? parseLanguageCode(langProp)
-    : widgetTheme.direction === 'rtl' ? 'HE' : 'EN';
+export default function ChatWidget({ config, langOverride }: ChatWidgetProps) {
+  const widgetTheme = getTheme(config.selectedTheme);
+  const initialLang: Language = langOverride
+    ? parseLanguageCode(langOverride)
+    : config.defaultLanguage;
 
   const [userName, setUserName] = useState<string>("");
   const [nameInput, setNameInput] = useState<string>("");
   const [messages, setMessages] = useState<Message[]>([]);
   const [inputMessage, setInputMessage] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [selectedFattalRooms, setSelectedFattalRooms] = useState<Map<number, FattalRoom>>(new Map());
-  const [selectedListing, setSelectedListing] = useState<WidgetListing | null>(null);
+  const [selectedFattalRooms, setSelectedFattalRooms] = useState<
+    Map<number, FattalRoom>
+  >(new Map());
+  const [selectedListing, setSelectedListing] = useState<WidgetListing | null>(
+    null
+  );
   const [currentLang, setCurrentLang] = useState<Language>(initialLang);
   const themeText = widgetTheme.text[currentLang];
   const messagesEndRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
 
-  // Apply theme CSS custom properties
-  useEffect(() => {
-    const root = document.documentElement;
-    root.style.setProperty('--theme-primary', widgetTheme.colors.primary);
-    root.style.setProperty('--theme-primary-light', widgetTheme.colors.primaryLight);
-    root.style.setProperty('--theme-accent', widgetTheme.colors.accent);
-    root.style.setProperty('--theme-background', widgetTheme.colors.background);
-    root.style.setProperty('--theme-accent-light', widgetTheme.colors.accentLight);
-  }, [widgetTheme]);
+  // Direction derived from current language
+  const direction: "ltr" | "rtl" = currentLang === "HE" ? "rtl" : "ltr";
 
   // Listen for agent messages forwarded from parent via postMessage
   useEffect(() => {
     const handleParentMessage = (event: MessageEvent) => {
-
       // For cross-origin embedding, accept messages with valid widget message types
       // from any origin (since we validate the message type and structure)
-      const hasValidMessageType = event.data?.type &&
+      const hasValidMessageType =
+        event.data?.type &&
         Object.values(ChatWidgetMessageType).includes(event.data.type);
 
       // Accept messages if they have valid message types (secure approach)
@@ -106,7 +106,6 @@ export default function ChatWidget({ theme: themeId, lang: langProp }: ChatWidge
       }
 
       if (event.data?.type === ChatWidgetMessageType.AGENT_MESSAGE) {
-
         // Add the agent message to the chat
         const agentMessage: Message = {
           id: Date.now().toString() + "-agent",
@@ -129,18 +128,13 @@ export default function ChatWidget({ theme: themeId, lang: langProp }: ChatWidge
 
         setMessages((prev) => [...prev, agentMessage]);
         setIsLoading(false);
-
-        // Refocus input field after agent response
-        setTimeout(() => {
-          inputRef.current?.focus();
-        }, 0);
       }
     };
 
-    window.addEventListener('message', handleParentMessage);
+    window.addEventListener("message", handleParentMessage);
 
     return () => {
-      window.removeEventListener('message', handleParentMessage);
+      window.removeEventListener("message", handleParentMessage);
     };
   }, []);
 
@@ -151,16 +145,22 @@ export default function ChatWidget({ theme: themeId, lang: langProp }: ChatWidge
 
   // Adjust widget size when hotel options or room search results are displayed
   useEffect(() => {
-    const hasHotelOptions = messages.some(msg => msg.hotelOptions && msg.hotelOptions.length > 0);
-    const hasRoomSearchResults = messages.some(msg => msg.roomSearchResults && msg.roomSearchResults.length > 0);
-    const hasListingOptions = messages.some(msg => msg.listingOptions && msg.listingOptions.length > 0);
+    const hasHotelOptions = messages.some(
+      (msg) => msg.hotelOptions && msg.hotelOptions.length > 0
+    );
+    const hasRoomSearchResults = messages.some(
+      (msg) => msg.roomSearchResults && msg.roomSearchResults.length > 0
+    );
+    const hasListingOptions = messages.some(
+      (msg) => msg.listingOptions && msg.listingOptions.length > 0
+    );
     const showingFattalRoomDetail = selectedFattalRooms.size > 0;
     const showingListingDetail = selectedListing !== null;
 
     // Send resize request to parent window
     if (window.parent && window.parent !== window) {
-      let newHeight = 500;
-      let newWidth = 350;
+      let newHeight = 640;
+      let newWidth = 380;
 
       if (showingFattalRoomDetail || showingListingDetail) {
         // Larger size for detail view
@@ -172,50 +172,40 @@ export default function ChatWidget({ theme: themeId, lang: langProp }: ChatWidge
         newWidth = 420;
       }
 
-      window.parent.postMessage({
-        type: 'CHAT_WIDGET_RESIZE',
-        height: newHeight,
-        width: newWidth
-      }, '*');
+      window.parent.postMessage(
+        {
+          type: "CHAT_WIDGET_RESIZE",
+          height: newHeight,
+          width: newWidth,
+        },
+        "*"
+      );
     }
   }, [messages, selectedFattalRooms, selectedListing]);
-
-  // Handle name submission
-  const handleNameSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!nameInput.trim()) return;
-
-    setUserName(nameInput.trim());
-
-    const welcome = widgetTheme.welcomeMessage(nameInput.trim());
-    const welcomeMessage: Message = {
-      id: Date.now().toString() + "-welcome",
-      text: welcome.text,
-      sender: "bot",
-      timestamp: new Date(),
-      direction: welcome.direction,
-    };
-
-    setMessages([welcomeMessage]);
-  };
 
   // Send message to API and get bot response
   const sendMessageToAPI = async (
     message: string,
-    userName: string,
-    formData?: Record<string, string | boolean>,
+    senderName: string,
+    formData?: Record<string, string | boolean>
   ): Promise<Message | null> => {
     try {
       // Use the widget messaging system for iframe communication
-      if (typeof window !== 'undefined' && window.parent && window.parent !== window) {
-
+      if (
+        typeof window !== "undefined" &&
+        window.parent &&
+        window.parent !== window
+      ) {
         // Use postMessage for iframe-to-parent communication
-        window.parent.postMessage({
-          type: ChatWidgetMessageType.SEND_MESSAGE,
-          message: message,
-          userName: userName,
-          ...(formData ? { formData } : {}),
-        }, '*');
+        window.parent.postMessage(
+          {
+            type: ChatWidgetMessageType.SEND_MESSAGE,
+            message: message,
+            userName: senderName,
+            ...(formData ? { formData } : {}),
+          },
+          "*"
+        );
 
         // Don't return a placeholder message - real response will come via Pusher
         return null; // Signal that we handled this via widget system
@@ -242,48 +232,91 @@ export default function ChatWidget({ theme: themeId, lang: langProp }: ChatWidge
     }
   };
 
-  // Handle message submission
-  const handleMessageSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!inputMessage.trim()) return;
-
-    const direction = detectTextDirection(inputMessage);
+  // Post a user bubble and forward to encoder — shared by text submit, quick actions, hotel/listing selection
+  const postUserMessage = async (text: string) => {
+    const msgDirection = detectTextDirection(text);
     const userMessage: Message = {
       id: Date.now().toString(),
-      text: inputMessage.trim(),
+      text,
       sender: "user",
       timestamp: new Date(),
-      direction,
+      direction: msgDirection,
     };
 
     setMessages((prev) => [...prev, userMessage]);
-    const messageText = inputMessage.trim();
-    setInputMessage("");
     setIsLoading(true);
 
-    // Keep focus on input for continued typing
-    setTimeout(() => inputRef.current?.focus(), 0);
-
-    const botReply = await sendMessageToAPI(messageText, userName);
+    const botReply = await sendMessageToAPI(text, userName);
     if (botReply) {
-      // Only add bot reply if it's not null (null means handled via widget system)
       setMessages((prev) => [...prev, botReply]);
       setIsLoading(false);
     }
     // When botReply is null (iframe mode), isLoading stays true until AGENT_MESSAGE arrives
   };
 
-  // Handle input change
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setInputMessage(e.target.value);
+  // Handle name submission (form submit — no quick action)
+  const handleNameSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!nameInput.trim()) return;
+
+    const name = nameInput.trim();
+    setUserName(name);
+
+    const welcome = widgetTheme.welcomeMessage(name);
+    const welcomeMessage: Message = {
+      id: Date.now().toString() + "-welcome",
+      text: welcome.text,
+      sender: "bot",
+      timestamp: new Date(),
+      direction: welcome.direction,
+    };
+
+    setMessages([welcomeMessage]);
   };
 
-  // Handle Enter key press
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
-      handleMessageSubmit(e as unknown as React.FormEvent<HTMLFormElement>);
+  // Handle quick action from welcome screen — name + welcome bubble + quick action user bubble, then API
+  const handleWelcomeQuickAction = async (id: QuickActionId) => {
+    if (!nameInput.trim()) return;
+
+    const name = nameInput.trim();
+    setUserName(name);
+
+    const welcome = widgetTheme.welcomeMessage(name);
+    const welcomeMessage: Message = {
+      id: Date.now().toString() + "-welcome",
+      text: welcome.text,
+      sender: "bot",
+      timestamp: new Date(),
+      direction: welcome.direction,
+    };
+
+    const prompt = getQuickActionPrompt(id, currentLang);
+    const promptDir = detectTextDirection(prompt);
+    const quickActionMessage: Message = {
+      id: Date.now().toString() + "-qa",
+      text: prompt,
+      sender: "user",
+      timestamp: new Date(),
+      direction: promptDir,
+    };
+
+    setMessages([welcomeMessage, quickActionMessage]);
+    setIsLoading(true);
+
+    const botReply = await sendMessageToAPI(prompt, name);
+    if (botReply) {
+      setMessages((prev) => [...prev, botReply]);
+      setIsLoading(false);
     }
+  };
+
+  // Handle message submission from Composer (no event — Composer calls onSubmit: () => void)
+  const handleMessageSubmit = () => {
+    if (!inputMessage.trim()) return;
+
+    const text = inputMessage.trim();
+    setInputMessage("");
+    void postUserMessage(text);
   };
 
   // Reset chat
@@ -295,32 +328,38 @@ export default function ChatWidget({ theme: themeId, lang: langProp }: ChatWidge
     setSelectedFattalRooms(new Map());
     setSelectedListing(null);
     // Notify parent page to clear conversationId and stop polling
-    window.parent.postMessage({ type: ChatWidgetMessageType.RESET_CHAT }, '*');
+    if (window.parent && window.parent !== window) {
+      window.parent.postMessage({ type: ChatWidgetMessageType.RESET_CHAT }, "*");
+    }
   };
 
   // Resolve the user-visible message based on formType
-  const getFormSubmittedMessage = (formData: Record<string, string | boolean>): string => {
+  const getFormSubmittedMessage = (
+    formData: Record<string, string | boolean>
+  ): string => {
     const formType = formData.formType as string | undefined;
     switch (formType) {
       case WidgetFormId.FATTAL_ID_COLLECT:
-        return t(currentLang, 'fattalIdSubmitted');
+        return t(currentLang, "fattalIdSubmitted");
       case WidgetFormId.FATTAL_OTP_VERIFY:
-        return t(currentLang, 'fattalOtpSubmitted');
+        return t(currentLang, "fattalOtpSubmitted");
       case WidgetFormId.FATTAL_CANCELLATION_CONFIRM:
         return formData.confirmed
-          ? t(currentLang, 'fattalCancelConfirmed')
-          : t(currentLang, 'fattalCancelDeclined');
+          ? t(currentLang, "fattalCancelConfirmed")
+          : t(currentLang, "fattalCancelDeclined");
       case WidgetFormId.FATTAL_CONTACT_UPDATE:
-        return t(currentLang, 'fattalContactUpdateSubmitted');
+        return t(currentLang, "fattalContactUpdateSubmitted");
       case WidgetFormId.GUESTY_GUEST_DETAILS:
-        return t(currentLang, 'guestyGuestDetailsSubmitted');
+        return t(currentLang, "guestyGuestDetailsSubmitted");
       default:
-        return t(currentLang, 'contactFormSubmitted');
+        return t(currentLang, "contactFormSubmitted");
     }
   };
 
   // Handle contact form submission
-  const handleContactFormSubmit = async (formData: Record<string, string | boolean>) => {
+  const handleContactFormSubmit = async (
+    formData: Record<string, string | boolean>
+  ) => {
     if (isLoading) return;
 
     const submittedMessage = getFormSubmittedMessage(formData);
@@ -393,23 +432,25 @@ export default function ChatWidget({ theme: themeId, lang: langProp }: ChatWidge
   ) => {
     if (isLoading) return;
 
-    const displayPrice = isClubMember && selectedPrice.clubTotalPrice
-      ? selectedPrice.clubTotalPrice
-      : selectedPrice.totalPrice;
+    const displayPrice =
+      isClubMember && selectedPrice.clubTotalPrice
+        ? selectedPrice.clubTotalPrice
+        : selectedPrice.totalPrice;
 
-    const selectionMessage = `${t(currentLang, 'bookingIntro')}\n` +
-      `${t(currentLang, 'roomLabel')}: ${room.name}\n` +
-      `${t(currentLang, 'packageLabel')}: ${selectedPackage.packageName}\n` +
-      `${t(currentLang, 'hostingTypeLabel')}: ${selectedPrice.hostingBase}\n` +
-      `${isClubMember ? t(currentLang, 'clubMemberYes') + '\n' : ''}` +
-      `${t(currentLang, 'priceLabel')}: ${formatPriceI18n(displayPrice, currentLang)} ₪`;
+    const selectionMessage =
+      `${t(currentLang, "bookingIntro")}\n` +
+      `${t(currentLang, "roomLabel")}: ${room.name}\n` +
+      `${t(currentLang, "packageLabel")}: ${selectedPackage.packageName}\n` +
+      `${t(currentLang, "hostingTypeLabel")}: ${selectedPrice.hostingBase}\n` +
+      `${isClubMember ? t(currentLang, "clubMemberYes") + "\n" : ""}` +
+      `${t(currentLang, "priceLabel")}: ${formatPriceI18n(displayPrice, currentLang)} ₪`;
 
     const userMessage: Message = {
       id: Date.now().toString(),
       text: selectionMessage,
       sender: "user",
       timestamp: new Date(),
-      direction: currentLang === 'HE' ? "rtl" : "ltr",
+      direction: currentLang === "HE" ? "rtl" : "ltr",
     };
 
     setMessages((prev) => [...prev, userMessage]);
@@ -461,289 +502,229 @@ export default function ChatWidget({ theme: themeId, lang: langProp }: ChatWidge
     }
   };
 
+  // ── Welcome screen ──────────────────────────────────────────────────────────
   if (!userName) {
     return (
-      <div dir={widgetTheme.direction} className="flex flex-col h-full sm:rounded-2xl overflow-hidden sm:shadow-xl">
-        <div className="bg-primary py-2 px-4 flex items-center gap-3">
-          <Image
-            src={widgetTheme.logoUrl}
-            priority={true}
-            alt="Logo"
-            width={widgetTheme.logoSize.width}
-            height={widgetTheme.logoSize.height}
-            className="object-contain"
-          />
-          <h2 className="text-lg font-bold text-white">
-            {themeText.welcomeTitle}
-          </h2>
-        </div>
-
-        <div className="flex-1 flex flex-col items-center justify-center p-6 bg-surface">
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            className="w-full max-w-md"
-          >
-            <form onSubmit={handleNameSubmit} className="space-y-4">
-              <div>
-                <label htmlFor="name" className="block text-sm font-medium mb-2 text-primary">
-                  {themeText.nameLabel}
-                </label>
-                <input
-                  id="name"
-                  type="text"
-                  value={nameInput}
-                  onChange={(e) => setNameInput(e.target.value)}
-                  className="w-full px-4 py-3 border-2 border-primary/20 rounded-xl
-                           bg-white text-primary focus:outline-none focus:border-accent
-                           placeholder:text-primary/50"
-                  placeholder={themeText.namePlaceholder}
-                  autoFocus
-                />
-              </div>
-              <motion.button
-                type="submit"
-                whileHover={{ scale: 1.02 }}
-                whileTap={{ scale: 0.98 }}
-                className="w-full bg-accent hover:bg-accent/90 text-white font-semibold py-3 px-4
-                          rounded-xl transition-colors shadow-md"
-              >
-                {themeText.startChat}
-              </motion.button>
-            </form>
-          </motion.div>
-        </div>
-
-        <div className="bg-white py-2 px-4 text-center border-t border-primary/10">
-          <p className="text-xs text-primary/60">
-            Powered by{" "}
-            <a
-              href="https://ersona.co"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-accent hover:text-accent/80 transition-colors font-medium"
-            >
-              Ersona
-            </a>
-          </p>
-        </div>
-      </div>
+      <WidgetShell
+        theme={widgetTheme}
+        showBackground={true}
+        backgroundImageUrl={config.backgroundImageUrl}
+        direction={direction}
+      >
+        <WelcomeScreen
+          theme={widgetTheme}
+          hotelName={config.hotelName}
+          logoUrl={config.logoUrl}
+          lang={currentLang}
+          nameInput={nameInput}
+          onNameInputChange={setNameInput}
+          onStart={handleNameSubmit}
+          quickActionsEnabled={config.quickActionsEnabled}
+          enabledQuickActions={config.enabledQuickActions}
+          onQuickAction={handleWelcomeQuickAction}
+          rightSlot={
+            config.showLanguageSelector ? (
+              <LanguageSelector
+                current={currentLang}
+                enabled={config.enabledLanguages}
+                onChange={setCurrentLang}
+              />
+            ) : undefined
+          }
+        />
+      </WidgetShell>
     );
   }
 
+  // ── Chat screen ─────────────────────────────────────────────────────────────
   return (
-    <div dir={widgetTheme.direction} className="flex flex-col h-full rounded-2xl overflow-hidden shadow-xl">
-      <div className="flex items-center justify-between py-2 px-4 bg-primary">
-        <h3 className="font-semibold flex items-center gap-2 text-white text-sm">
-          <Image
-            src={widgetTheme.logoUrl}
-            priority={true}
-            alt="Logo"
-            width={24}
-            height={24}
-            className="object-contain"
-          />
-          <span>{themeText.headerTitle}</span>
-        </h3>
-        <button
-          onClick={resetChat}
-          className="text-sm text-white/80 hover:text-white transition-colors"
-        >
-          {themeText.resetButton}
-        </button>
-      </div>
+    <WidgetShell
+      theme={widgetTheme}
+      showBackground={false}
+      backgroundImageUrl={null}
+      direction={direction}
+    >
+      <ChatHeader
+        theme={widgetTheme}
+        hotelName={config.hotelName}
+        logoUrl={config.logoUrl}
+        lang={currentLang}
+        onReset={resetChat}
+        rightSlot={
+          config.showLanguageSelector ? (
+            <LanguageSelector
+              current={currentLang}
+              enabled={config.enabledLanguages}
+              onChange={setCurrentLang}
+            />
+          ) : undefined
+        }
+      />
 
-      {/* Messages - Cream background */}
-      <div className="flex-1 overflow-y-auto overscroll-contain p-4 space-y-4 bg-surface" style={{ WebkitOverflowScrolling: "touch" }}>
-        <AnimatePresence>
+      {/* Message list */}
+      <div
+        className="flex-1 overflow-y-auto px-3 py-4 space-y-4 bg-background"
+        aria-live="polite"
+        aria-atomic="false"
+      >
+        <AnimatePresence initial={false}>
           {messages.map((message, index) => (
-            <div key={message.id}>
-              {/* Message Bubble */}
-              <motion.div
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: -20 }}
-                className={`flex ${
-                  message.sender === "user" ? "justify-end" : "justify-start"
-                }`}
-              >
-                <div
-                  dir={message.direction}
-                  className={`max-w-xs lg:max-w-md px-4 py-3 rounded-2xl shadow-sm ${
-                    message.sender === "user"
-                      ? "bg-accent text-primary"
-                      : "bg-white text-primary border border-primary/10"
-                  }`}
-                >
-                  <div className="text-sm prose prose-sm max-w-none [&>p]:m-0 [&>ul]:m-0 [&>ol]:m-0 [&>p+p]:mt-2 whitespace-pre-wrap">
-                    <Markdown
-                      components={{
-                        a: ({ href, children }) => (
-                          <MarkdownLink href={href} isUserMessage={message.sender === "user"}>
-                            {children}
-                          </MarkdownLink>
-                        ),
-                        strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
-                        em: ({ children }) => <em className="italic">{children}</em>,
-                      }}
-                    >
-                      {message.text}
-                    </Markdown>
-                  </div>
-                  <p className={`text-xs mt-2 ${
-                    message.sender === "user" ? "text-primary/60" : "text-primary/50"
-                  }`}>
-                    {message.timestamp.toLocaleTimeString([], {
-                      hour: "2-digit",
-                      minute: "2-digit",
-                    })}
-                  </p>
-                </div>
-              </motion.div>
-
-              {/* Form rendering based on formId */}
-              {message.formId === WidgetFormId.CONTACT_INFO && (
-                <ContactForm
-                  lang={currentLang}
-                  onSubmit={handleContactFormSubmit}
-                  disabled={isLoading}
-                />
-              )}
-              {message.formId === WidgetFormId.FATTAL_ID_COLLECT && (
-                <FattalIdCollectForm
-                  lang={currentLang}
-                  onSubmit={handleContactFormSubmit}
-                  disabled={isLoading}
-                />
-              )}
-              {message.formId === WidgetFormId.FATTAL_OTP_VERIFY && (
-                <FattalOtpVerifyForm
-                  lang={currentLang}
-                  onSubmit={handleContactFormSubmit}
-                  disabled={isLoading}
-                />
-              )}
-              {message.formId === WidgetFormId.FATTAL_CANCELLATION_CONFIRM && (
-                <FattalCancellationForm
-                  lang={currentLang}
-                  onSubmit={handleContactFormSubmit}
-                  disabled={isLoading}
-                  formData={message.formData as React.ComponentProps<typeof FattalCancellationForm>["formData"]}
-                />
-              )}
-              {message.formId === WidgetFormId.FATTAL_CONTACT_UPDATE && (
-                <FattalContactUpdateForm
-                  lang={currentLang}
-                  onSubmit={handleContactFormSubmit as React.ComponentProps<typeof FattalContactUpdateForm>["onSubmit"]}
-                  disabled={isLoading}
-                  formData={message.formData as React.ComponentProps<typeof FattalContactUpdateForm>["formData"]}
-                />
-              )}
-              {message.formId === WidgetFormId.GUESTY_GUEST_DETAILS && (
-                <GuestDetailsForm
-                  lang={currentLang}
-                  onSubmit={handleContactFormSubmit}
-                  disabled={isLoading}
-                  formData={message.formData as React.ComponentProps<typeof GuestDetailsForm>["formData"]}
-                />
-              )}
-
-              {/* Hotel Carousel (Fattal) */}
-              {message.hotelOptions && message.hotelOptions.length > 0 && (
-                <HotelCarousel hotels={message.hotelOptions} onSelectHotel={handleSelectHotel} lang={currentLang} />
-              )}
-
-              {/* Fattal Room Carousel or Detail View */}
-              {message.roomSearchResults && message.roomSearchResults.length > 0 && (
-                <>
-                  {selectedFattalRooms.get(index) ? (
-                    <FattalRoomDetailView
-                      room={selectedFattalRooms.get(index)!}
-                      onConfirm={(room, pkg, price, isClubMember) => handleConfirmFattalRoom(index, room, pkg, price, isClubMember)}
-                      onBack={() => handleBackFromFattalRoom(index)}
-                      lang={currentLang}
-                    />
-                  ) : (
-                    <FattalRoomCarousel rooms={message.roomSearchResults} onSelectRoom={(room) => handleSelectFattalRoom(index, room)} lang={currentLang} />
-                  )}
-                </>
-              )}
-
-              {/* Listing Carousel or Detail View */}
-              {message.listingOptions && message.listingOptions.length > 0 && (
-                <>
-                  {selectedListing ? (
-                    <ListingDetailView
-                      listing={selectedListing}
-                      onSelect={handleSelectListing}
-                      onBack={handleBackFromListingDetail}
-                      lang={currentLang}
-                    />
-                  ) : (
-                    <ListingCarousel listings={message.listingOptions} onViewDetails={handleViewListingDetails} lang={currentLang} />
-                  )}
-                </>
-              )}
-            </div>
-          ))}
-          {/* Typing indicator */}
-          {isLoading && (
             <motion.div
-              initial={{ opacity: 0, y: 10 }}
+              key={message.id}
+              initial={{ opacity: 0, y: 6 }}
               animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.2, ease: "easeOut" }}
-              className="flex justify-start"
+              transition={{ duration: 0.18 }}
             >
-              <LoadingSpinner />
+              <MessageBubble
+                sender={message.sender}
+                text={message.text}
+                timestamp={message.timestamp}
+                direction={message.direction}
+              >
+                {/* Form rendering based on formId */}
+                {message.formId === WidgetFormId.CONTACT_INFO && (
+                  <ContactForm
+                    lang={currentLang}
+                    onSubmit={handleContactFormSubmit}
+                    disabled={isLoading}
+                  />
+                )}
+                {message.formId === WidgetFormId.FATTAL_ID_COLLECT && (
+                  <FattalIdCollectForm
+                    lang={currentLang}
+                    onSubmit={handleContactFormSubmit}
+                    disabled={isLoading}
+                  />
+                )}
+                {message.formId === WidgetFormId.FATTAL_OTP_VERIFY && (
+                  <FattalOtpVerifyForm
+                    lang={currentLang}
+                    onSubmit={handleContactFormSubmit}
+                    disabled={isLoading}
+                  />
+                )}
+                {message.formId === WidgetFormId.FATTAL_CANCELLATION_CONFIRM && (
+                  <FattalCancellationForm
+                    lang={currentLang}
+                    onSubmit={handleContactFormSubmit}
+                    disabled={isLoading}
+                    formData={
+                      message.formData as React.ComponentProps<
+                        typeof FattalCancellationForm
+                      >["formData"]
+                    }
+                  />
+                )}
+                {message.formId === WidgetFormId.FATTAL_CONTACT_UPDATE && (
+                  <FattalContactUpdateForm
+                    lang={currentLang}
+                    onSubmit={
+                      handleContactFormSubmit as React.ComponentProps<
+                        typeof FattalContactUpdateForm
+                      >["onSubmit"]
+                    }
+                    disabled={isLoading}
+                    formData={
+                      message.formData as React.ComponentProps<
+                        typeof FattalContactUpdateForm
+                      >["formData"]
+                    }
+                  />
+                )}
+                {message.formId === WidgetFormId.GUESTY_GUEST_DETAILS && (
+                  <GuestDetailsForm
+                    lang={currentLang}
+                    onSubmit={handleContactFormSubmit}
+                    disabled={isLoading}
+                    formData={
+                      message.formData as React.ComponentProps<
+                        typeof GuestDetailsForm
+                      >["formData"]
+                    }
+                  />
+                )}
+
+                {/* Hotel Carousel (Fattal) */}
+                {message.hotelOptions && message.hotelOptions.length > 0 && (
+                  <HotelCarousel
+                    hotels={message.hotelOptions}
+                    onSelectHotel={handleSelectHotel}
+                    lang={currentLang}
+                  />
+                )}
+
+                {/* Fattal Room Carousel or Detail View */}
+                {message.roomSearchResults &&
+                  message.roomSearchResults.length > 0 && (
+                    <>
+                      {selectedFattalRooms.get(index) ? (
+                        <FattalRoomDetailView
+                          room={selectedFattalRooms.get(index)!}
+                          onConfirm={(room, pkg, price, isClubMember) =>
+                            handleConfirmFattalRoom(
+                              index,
+                              room,
+                              pkg,
+                              price,
+                              isClubMember
+                            )
+                          }
+                          onBack={() => handleBackFromFattalRoom(index)}
+                          lang={currentLang}
+                        />
+                      ) : (
+                        <FattalRoomCarousel
+                          rooms={message.roomSearchResults}
+                          onSelectRoom={(room) =>
+                            handleSelectFattalRoom(index, room)
+                          }
+                          lang={currentLang}
+                        />
+                      )}
+                    </>
+                  )}
+
+                {/* Listing Carousel or Detail View */}
+                {message.listingOptions &&
+                  message.listingOptions.length > 0 && (
+                    <>
+                      {selectedListing ? (
+                        <ListingDetailView
+                          listing={selectedListing}
+                          onSelect={handleSelectListing}
+                          onBack={handleBackFromListingDetail}
+                          lang={currentLang}
+                        />
+                      ) : (
+                        <ListingCarousel
+                          listings={message.listingOptions}
+                          onViewDetails={handleViewListingDetails}
+                          lang={currentLang}
+                        />
+                      )}
+                    </>
+                  )}
+              </MessageBubble>
             </motion.div>
+          ))}
+          {isLoading && (
+            <div className="flex justify-start">
+              <LoadingSpinner />
+            </div>
           )}
         </AnimatePresence>
         <div ref={messagesEndRef} />
       </div>
 
-      {/* Input - White background */}
-      <div className="p-4 bg-white border-t border-primary/10">
-        <form onSubmit={handleMessageSubmit} className="flex gap-2">
-          <input
-            ref={inputRef}
-            type="text"
-            value={inputMessage}
-            onChange={handleInputChange}
-            onKeyDown={handleKeyDown}
-            dir="auto"
-            className="flex-1 px-4 py-3 border-2 border-primary/20 rounded-xl
-                     bg-white text-primary focus:outline-none focus:border-accent
-                     text-sm placeholder:text-primary/40"
-            placeholder={themeText.inputPlaceholder}
-          />
-          <motion.button
-            type="submit"
-            disabled={!inputMessage.trim()}
-            whileHover={{ scale: 1.05 }}
-            whileTap={{ scale: 0.95 }}
-            className="bg-accent hover:bg-accent/90 text-white font-medium p-3
-                     rounded-xl transition-colors flex items-center justify-center
-                     disabled:opacity-50 disabled:cursor-not-allowed shadow-md"
-          >
-            <LuSendHorizontal className={`w-5 h-5 transition-transform ${widgetTheme.direction === "rtl" ? "rotate-180" : ""}`} />
-          </motion.button>
-        </form>
-      </div>
-
-      {/* Footer */}
-      <div className="py-2 px-4 bg-white text-center">
-        <p className="text-xs text-primary/50">
-          Powered by:{" "}
-          <a
-            href="https://ersona.co"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-accent hover:text-accent/80 transition-colors font-medium"
-          >
-            Ersona
-          </a>
-        </p>
-      </div>
-    </div>
+      <Composer
+        value={inputMessage}
+        onChange={setInputMessage}
+        onSubmit={handleMessageSubmit}
+        placeholder={themeText.inputPlaceholder}
+        disabled={isLoading}
+        direction={direction}
+        formLabel={currentLang === "HE" ? "כתיבת הודעה" : "Message composer"}
+      />
+    </WidgetShell>
   );
 }

--- a/src/components/FattalCancellationForm.tsx
+++ b/src/components/FattalCancellationForm.tsx
@@ -82,7 +82,7 @@ export default function FattalCancellationForm({
 
         {/* Order details */}
         {formData && (
-          <div className="bg-gray-50 rounded-lg p-3 space-y-1.5 text-xs text-primary/80">
+          <div className="bg-text/[0.04] rounded-lg p-3 space-y-1.5 text-xs text-primary/80">
             <div className="flex justify-between">
               <span className="font-medium">{t(lang, "fattalCancelHotel")}</span>
               <span>{formData.hotel}</span>
@@ -103,7 +103,7 @@ export default function FattalCancellationForm({
               <span className="font-medium">{t(lang, "fattalCancelPlan")}</span>
               <span>{formData.plan}</span>
             </div>
-            <div className="border-t border-gray-200 pt-1.5 flex justify-between font-semibold text-primary">
+            <div className="border-t border-border pt-1.5 flex justify-between font-semibold text-primary">
               <span>{t(lang, "fattalCancelTotal")}</span>
               <span dir="ltr">₪{formData.totalPrice}</span>
             </div>
@@ -133,8 +133,8 @@ export default function FattalCancellationForm({
             disabled={disabled || submitted}
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
-            className="flex-1 bg-gray-100 hover:bg-gray-200 text-primary font-semibold py-2.5 px-4
-                     rounded-lg transition-colors shadow-sm text-sm border border-gray-200
+            className="flex-1 bg-text/[0.04] hover:bg-text/[0.08] text-primary font-semibold py-2.5 px-4
+                     rounded-lg transition-colors shadow-sm text-sm border border-border
                      disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {t(lang, "fattalCancelDecline")}

--- a/src/components/FattalContactUpdateForm.tsx
+++ b/src/components/FattalContactUpdateForm.tsx
@@ -83,7 +83,7 @@ function FieldRow({
 }
 
 const inputBaseClass =
-  "w-full text-sm border border-gray-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-1 focus:ring-primary/30 disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-gray-50";
+  "w-full text-sm border border-border rounded-lg px-3 py-2 focus:outline-none focus:ring-1 focus:ring-primary/30 disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-text/[0.04]";
 
 export default function FattalContactUpdateForm({
   lang: defaultLang,
@@ -221,7 +221,7 @@ export default function FattalContactUpdateForm({
             value={preferredMonth}
             onChange={(e) => setPreferredMonth(e.target.value)}
             disabled={disabled || !!formData?.hasPreferredMonth}
-            className="w-full text-sm border border-gray-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-1 focus:ring-primary/30 disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-gray-50 cursor-pointer"
+            className="w-full text-sm border border-border rounded-lg px-3 py-2 focus:outline-none focus:ring-1 focus:ring-primary/30 disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-text/[0.04] cursor-pointer"
           >
             <option value="">—</option>
             {Array.from({ length: 12 }, (_, i) => i + 1).map((m) => (

--- a/src/components/FullPageChatWidget.tsx
+++ b/src/components/FullPageChatWidget.tsx
@@ -2,11 +2,15 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { LuSendHorizontal } from "react-icons/lu";
-import Image from "next/image";
-import Markdown from "react-markdown";
 import LoadingSpinner from "./LoadingSpinner";
-import { FattalHotel, FattalRoom, FattalRoomPackage, FattalPackagePrice, WidgetListing, WidgetFormId } from "@/types/message-types";
+import {
+  FattalHotel,
+  FattalRoom,
+  FattalRoomPackage,
+  FattalPackagePrice,
+  WidgetListing,
+  WidgetFormId,
+} from "@/types/message-types";
 import HotelCarousel from "./HotelCarousel";
 import FattalRoomCarousel from "./FattalRoomCarousel";
 import FattalRoomDetailView from "./FattalRoomDetailView";
@@ -18,8 +22,23 @@ import FattalOtpVerifyForm from "./FattalOtpVerifyForm";
 import FattalCancellationForm from "./FattalCancellationForm";
 import FattalContactUpdateForm from "./FattalContactUpdateForm";
 import GuestDetailsForm from "./GuestDetailsForm";
-import { Language, t, formatPrice as formatPriceI18n, parseLanguageCode } from "@/utils/i18n";
+import {
+  Language,
+  t,
+  formatPrice as formatPriceI18n,
+  parseLanguageCode,
+} from "@/utils/i18n";
 import { getTheme } from "@/config/theme-config";
+import type { WidgetConfig, QuickActionId } from "@/config/widget-config";
+import { getQuickActionPrompt } from "@/config/quick-actions";
+
+// Shell components
+import WidgetShell from "./shell/WidgetShell";
+import WelcomeScreen from "./shell/WelcomeScreen";
+import ChatHeader from "./shell/ChatHeader";
+import MessageBubble from "./shell/MessageBubble";
+import Composer from "./shell/Composer";
+import LanguageSelector from "./shell/LanguageSelector";
 
 interface Message {
   id: string;
@@ -35,7 +54,7 @@ interface Message {
   languageCode?: string;
 }
 
-const HEBREW_REGEX = /[\u0590-\u05FF]/;
+const HEBREW_REGEX = /[֐-׿]/;
 const POLLING_INTERVAL_MS = 2500;
 const INACTIVITY_TIMEOUT_MS = 60 * 60 * 1000; // 1 hour
 
@@ -43,42 +62,36 @@ const detectTextDirection = (text: string): "ltr" | "rtl" => {
   return HEBREW_REGEX.test(text.charAt(0)) ? "rtl" : "ltr";
 };
 
-const MarkdownLink = ({ href, children, isUserMessage }: { href?: string; children: React.ReactNode; isUserMessage: boolean }) => (
-  <a
-    href={href}
-    target="_blank"
-    rel="noopener noreferrer"
-    className={`underline hover:no-underline transition-colors font-medium ${
-      isUserMessage
-        ? "text-primary/80 hover:text-primary"
-        : "text-primary font-semibold hover:text-primary/80"
-    }`}
-  >
-    {children}
-  </a>
-);
-
 interface FullPageChatWidgetProps {
-  widgetId: string;
-  theme?: string | null;
-  lang?: string | null;
+  config: WidgetConfig;
+  langOverride?: string | null;
 }
 
-export default function FullPageChatWidget({ widgetId, theme: themeId, lang: langProp }: FullPageChatWidgetProps) {
-  const widgetTheme = getTheme(themeId);
-  const initialLang: Language = langProp
-    ? parseLanguageCode(langProp)
-    : widgetTheme.direction === 'rtl' ? 'HE' : 'EN';
+export default function FullPageChatWidget({
+  config,
+  langOverride,
+}: FullPageChatWidgetProps) {
+  const widgetTheme = getTheme(config.selectedTheme);
+  const initialLang: Language = langOverride
+    ? parseLanguageCode(langOverride)
+    : config.defaultLanguage;
 
   const [userName, setUserName] = useState<string>("");
   const [nameInput, setNameInput] = useState<string>("");
   const [messages, setMessages] = useState<Message[]>([]);
   const [inputMessage, setInputMessage] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [selectedFattalRooms, setSelectedFattalRooms] = useState<Map<number, FattalRoom>>(new Map());
-  const [selectedListing, setSelectedListing] = useState<WidgetListing | null>(null);
+  const [selectedFattalRooms, setSelectedFattalRooms] = useState<
+    Map<number, FattalRoom>
+  >(new Map());
+  const [selectedListing, setSelectedListing] = useState<WidgetListing | null>(
+    null
+  );
   const [currentLang, setCurrentLang] = useState<Language>(initialLang);
   const themeText = widgetTheme.text[currentLang];
+
+  // Direction derived from current language
+  const direction: "ltr" | "rtl" = currentLang === "HE" ? "rtl" : "ltr";
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -87,16 +100,6 @@ export default function FullPageChatWidget({ widgetId, theme: themeId, lang: lan
   const lastActivityRef = useRef<number>(Date.now());
   const epochRef = useRef(0);
   const welcomeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Apply theme CSS custom properties
-  useEffect(() => {
-    const root = document.documentElement;
-    root.style.setProperty('--theme-primary', widgetTheme.colors.primary);
-    root.style.setProperty('--theme-primary-light', widgetTheme.colors.primaryLight);
-    root.style.setProperty('--theme-accent', widgetTheme.colors.accent);
-    root.style.setProperty('--theme-background', widgetTheme.colors.background);
-    root.style.setProperty('--theme-accent-light', widgetTheme.colors.accentLight);
-  }, [widgetTheme]);
 
   // Auto-scroll to bottom when new messages arrive
   useEffect(() => {
@@ -110,43 +113,58 @@ export default function FullPageChatWidget({ widgetId, theme: themeId, lang: lan
     }
   }, []);
 
-  const startPolling = useCallback((conversationId: string) => {
-    stopPolling();
-    pollingIntervalRef.current = setInterval(async () => {
-      const myEpoch = epochRef.current;
-      if (Date.now() - lastActivityRef.current > INACTIVITY_TIMEOUT_MS) {
-        stopPolling();
-        return;
-      }
-      try {
-        const res = await fetch(`/api/widget/poll?conversationId=${conversationId}`);
-        if (!res.ok) return;
-        if (epochRef.current !== myEpoch) return;
-        const body = await res.json();
-        const data = body.data; // unwrap from { success, data }
-        if (!data?.message && !data?.hotelOptions && !data?.listingOptions && !data?.roomSearchResults && !data?.formId) return;
-        if (data.languageCode) setCurrentLang(parseLanguageCode(data.languageCode));
-        setMessages((prev) => [...prev, {
-          id: Date.now().toString() + "-agent",
-          text: data.message ?? "",
-          sender: "bot",
-          timestamp: new Date(),
-          direction: detectTextDirection(data.message ?? ""),
-          hotelOptions: data.hotelOptions ?? undefined,
-          roomSearchResults: data.roomSearchResults ?? undefined,
-          listingOptions: data.listingOptions ?? undefined,
-          formId: data.formId ?? undefined,
-          formData: data.formData ?? undefined,
-          languageCode: data.languageCode ?? undefined,
-        }]);
-        setIsLoading(false);
-        lastActivityRef.current = Date.now();
-        setTimeout(() => inputRef.current?.focus(), 0);
-      } catch {
-        // silently ignore polling errors
-      }
-    }, POLLING_INTERVAL_MS);
-  }, [stopPolling]);
+  const startPolling = useCallback(
+    (conversationId: string) => {
+      stopPolling();
+      pollingIntervalRef.current = setInterval(async () => {
+        const myEpoch = epochRef.current;
+        if (Date.now() - lastActivityRef.current > INACTIVITY_TIMEOUT_MS) {
+          stopPolling();
+          return;
+        }
+        try {
+          const res = await fetch(
+            `/api/widget/poll?conversationId=${conversationId}`
+          );
+          if (!res.ok) return;
+          if (epochRef.current !== myEpoch) return;
+          const body = await res.json();
+          const data = body.data; // unwrap from { success, data }
+          if (
+            !data?.message &&
+            !data?.hotelOptions &&
+            !data?.listingOptions &&
+            !data?.roomSearchResults &&
+            !data?.formId
+          )
+            return;
+          if (data.languageCode) setCurrentLang(parseLanguageCode(data.languageCode));
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: Date.now().toString() + "-agent",
+              text: data.message ?? "",
+              sender: "bot",
+              timestamp: new Date(),
+              direction: detectTextDirection(data.message ?? ""),
+              hotelOptions: data.hotelOptions ?? undefined,
+              roomSearchResults: data.roomSearchResults ?? undefined,
+              listingOptions: data.listingOptions ?? undefined,
+              formId: data.formId ?? undefined,
+              formData: data.formData ?? undefined,
+              languageCode: data.languageCode ?? undefined,
+            },
+          ]);
+          setIsLoading(false);
+          lastActivityRef.current = Date.now();
+          setTimeout(() => inputRef.current?.focus(), 0);
+        } catch {
+          // silently ignore polling errors
+        }
+      }, POLLING_INTERVAL_MS);
+    },
+    [stopPolling]
+  );
 
   // Cleanup on unmount
   useEffect(() => {
@@ -156,38 +174,59 @@ export default function FullPageChatWidget({ widgetId, theme: themeId, lang: lan
     };
   }, [stopPolling]);
 
-  const sendMessageToAPI = useCallback(async (
-    message: string,
-    currentUserName: string,
-    formData?: Record<string, string | boolean>,
-  ) => {
-    if (!conversationIdRef.current) {
-      conversationIdRef.current = crypto.randomUUID();
-      startPolling(conversationIdRef.current);
-    }
-    lastActivityRef.current = Date.now();
-    try {
-      const res = await fetch("/api/widget/messages", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          companyId: widgetId,
-          conversationId: conversationIdRef.current,
-          message,
-          userName: currentUserName,
-          timestamp: new Date().toISOString(),
-          ...(formData ? { formData } : {}),
-        }),
-      });
-      if (!res.ok) {
+  const sendMessageToAPI = useCallback(
+    async (
+      message: string,
+      currentUserName: string,
+      formData?: Record<string, string | boolean>
+    ) => {
+      if (!conversationIdRef.current) {
+        conversationIdRef.current = crypto.randomUUID();
+        startPolling(conversationIdRef.current);
+      }
+      lastActivityRef.current = Date.now();
+      try {
+        const res = await fetch("/api/widget/messages", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            widgetId: config.widgetId,
+            conversationId: conversationIdRef.current,
+            message,
+            userName: currentUserName,
+            timestamp: new Date().toISOString(),
+            ...(formData ? { formData } : {}),
+          }),
+        });
+        if (!res.ok) {
+          setIsLoading(false);
+        }
+      } catch {
         setIsLoading(false);
       }
-    } catch {
-      setIsLoading(false);
-    }
-  }, [widgetId, startPolling]);
+    },
+    [config.widgetId, startPolling]
+  );
 
-  // Handle name submission
+  // Post a user bubble and forward to encoder — shared by text submit and quick actions
+  const postUserMessage = useCallback(
+    async (text: string) => {
+      const userMessage: Message = {
+        id: Date.now().toString(),
+        text,
+        sender: "user",
+        timestamp: new Date(),
+        direction: detectTextDirection(text),
+      };
+      setMessages((prev) => [...prev, userMessage]);
+      setIsLoading(true);
+      await sendMessageToAPI(text, userName);
+      // isLoading stays true until poll receives response
+    },
+    [sendMessageToAPI, userName]
+  );
+
+  // Handle name submission (form submit — no quick action)
   const handleNameSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!nameInput.trim()) return;
@@ -206,44 +245,45 @@ export default function FullPageChatWidget({ widgetId, theme: themeId, lang: lan
     setMessages([welcomeMessage]);
   };
 
-  // Handle message submission
-  const handleMessageSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!inputMessage.trim()) return;
+  // Handle quick action from welcome screen — name + welcome bubble + quick action user bubble, then API
+  const handleWelcomeQuickAction = async (id: QuickActionId) => {
+    if (!nameInput.trim()) return;
 
-    const userMessage: Message = {
-      id: Date.now().toString(),
-      text: inputMessage.trim(),
-      sender: "user",
+    const name = nameInput.trim();
+    setUserName(name);
+
+    const welcome = widgetTheme.welcomeMessage(name);
+    const welcomeMessage: Message = {
+      id: Date.now().toString() + "-welcome",
+      text: welcome.text,
+      sender: "bot",
       timestamp: new Date(),
-      direction: detectTextDirection(inputMessage),
+      direction: welcome.direction,
     };
 
-    setMessages((prev) => [...prev, userMessage]);
-    const messageText = inputMessage.trim();
-    setInputMessage("");
+    const prompt = getQuickActionPrompt(id, currentLang);
+    const quickActionMessage: Message = {
+      id: Date.now().toString() + "-quickaction",
+      text: prompt,
+      sender: "user",
+      timestamp: new Date(),
+      direction: detectTextDirection(prompt),
+    };
+
+    setMessages([welcomeMessage, quickActionMessage]);
     setIsLoading(true);
-
-    setTimeout(() => inputRef.current?.focus(), 0);
-
-    await sendMessageToAPI(messageText, userName);
-    // isLoading stays true until poll receives response
+    void sendMessageToAPI(prompt, name);
   };
 
-  // Handle input change
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setInputMessage(e.target.value);
+  // Handle message submission from Composer (no event — Composer calls onSubmit: () => void)
+  const handleMessageSubmit = () => {
+    if (!inputMessage.trim()) return;
+    const text = inputMessage.trim();
+    setInputMessage("");
+    void postUserMessage(text);
   };
 
-  // Handle Enter key press
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
-      handleMessageSubmit(e as unknown as React.FormEvent<HTMLFormElement>);
-    }
-  };
-
-  // Reset chat
+  // Reset chat (no postMessage — standalone full-page widget)
   const resetChat = () => {
     stopPolling();
     epochRef.current += 1;
@@ -256,28 +296,32 @@ export default function FullPageChatWidget({ widgetId, theme: themeId, lang: lan
     setSelectedListing(null);
   };
 
-  const getFormSubmittedMessage = (formData: Record<string, string | boolean>): string => {
+  const getFormSubmittedMessage = (
+    formData: Record<string, string | boolean>
+  ): string => {
     const formType = formData.formType as string | undefined;
     switch (formType) {
       case WidgetFormId.FATTAL_ID_COLLECT:
-        return t(currentLang, 'fattalIdSubmitted');
+        return t(currentLang, "fattalIdSubmitted");
       case WidgetFormId.FATTAL_OTP_VERIFY:
-        return t(currentLang, 'fattalOtpSubmitted');
+        return t(currentLang, "fattalOtpSubmitted");
       case WidgetFormId.FATTAL_CANCELLATION_CONFIRM:
         return formData.confirmed
-          ? t(currentLang, 'fattalCancelConfirmed')
-          : t(currentLang, 'fattalCancelDeclined');
+          ? t(currentLang, "fattalCancelConfirmed")
+          : t(currentLang, "fattalCancelDeclined");
       case WidgetFormId.FATTAL_CONTACT_UPDATE:
-        return t(currentLang, 'fattalContactUpdateSubmitted');
+        return t(currentLang, "fattalContactUpdateSubmitted");
       case WidgetFormId.GUESTY_GUEST_DETAILS:
-        return t(currentLang, 'guestyGuestDetailsSubmitted');
+        return t(currentLang, "guestyGuestDetailsSubmitted");
       default:
-        return t(currentLang, 'contactFormSubmitted');
+        return t(currentLang, "contactFormSubmitted");
     }
   };
 
   // Handle contact form submission
-  const handleContactFormSubmit = async (formData: Record<string, string | boolean>) => {
+  const handleContactFormSubmit = async (
+    formData: Record<string, string | boolean>
+  ) => {
     if (isLoading) return;
 
     const submittedMessage = getFormSubmittedMessage(formData);
@@ -322,6 +366,7 @@ export default function FullPageChatWidget({ widgetId, theme: themeId, lang: lan
       return next;
     });
   };
+
   const handleBackFromFattalRoom = (messageIndex: number) => {
     setSelectedFattalRooms((prev) => {
       const next = new Map(prev);
@@ -339,23 +384,25 @@ export default function FullPageChatWidget({ widgetId, theme: themeId, lang: lan
   ) => {
     if (isLoading) return;
 
-    const displayPrice = isClubMember && selectedPrice.clubTotalPrice
-      ? selectedPrice.clubTotalPrice
-      : selectedPrice.totalPrice;
+    const displayPrice =
+      isClubMember && selectedPrice.clubTotalPrice
+        ? selectedPrice.clubTotalPrice
+        : selectedPrice.totalPrice;
 
-    const selectionMessage = `${t(currentLang, 'bookingIntro')}\n` +
-      `${t(currentLang, 'roomLabel')}: ${room.name}\n` +
-      `${t(currentLang, 'packageLabel')}: ${selectedPackage.packageName}\n` +
-      `${t(currentLang, 'hostingTypeLabel')}: ${selectedPrice.hostingBase}\n` +
-      `${isClubMember ? t(currentLang, 'clubMemberYes') + '\n' : ''}` +
-      `${t(currentLang, 'priceLabel')}: ${formatPriceI18n(displayPrice, currentLang)} ₪`;
+    const selectionMessage =
+      `${t(currentLang, "bookingIntro")}\n` +
+      `${t(currentLang, "roomLabel")}: ${room.name}\n` +
+      `${t(currentLang, "packageLabel")}: ${selectedPackage.packageName}\n` +
+      `${t(currentLang, "hostingTypeLabel")}: ${selectedPrice.hostingBase}\n` +
+      `${isClubMember ? t(currentLang, "clubMemberYes") + "\n" : ""}` +
+      `${t(currentLang, "priceLabel")}: ${formatPriceI18n(displayPrice, currentLang)} ₪`;
 
     const userMessage: Message = {
       id: Date.now().toString(),
       text: selectionMessage,
       sender: "user",
       timestamp: new Date(),
-      direction: currentLang === 'HE' ? "rtl" : "ltr",
+      direction: currentLang === "HE" ? "rtl" : "ltr",
     };
 
     setMessages((prev) => [...prev, userMessage]);
@@ -370,8 +417,13 @@ export default function FullPageChatWidget({ widgetId, theme: themeId, lang: lan
     // isLoading stays true until poll receives response
   };
 
-  const handleViewListingDetails = (listing: WidgetListing) => { setSelectedListing(listing); };
-  const handleBackFromListingDetail = () => { setSelectedListing(null); };
+  const handleViewListingDetails = (listing: WidgetListing) => {
+    setSelectedListing(listing);
+  };
+
+  const handleBackFromListingDetail = () => {
+    setSelectedListing(null);
+  };
 
   const handleSelectListing = async (listing: WidgetListing) => {
     if (isLoading) return;
@@ -392,281 +444,229 @@ export default function FullPageChatWidget({ widgetId, theme: themeId, lang: lan
     // isLoading stays true until poll receives response
   };
 
+  // ── Welcome screen ──────────────────────────────────────────────────────────
   if (!userName) {
     return (
-      <div dir={widgetTheme.direction} className="flex flex-col h-dvh w-screen overflow-hidden">
-        <div className="bg-primary py-2 px-4 flex items-center gap-3">
-          <Image
-            src={widgetTheme.logoUrl}
-            priority={true}
-            alt="Logo"
-            width={widgetTheme.logoSize.width}
-            height={widgetTheme.logoSize.height}
-            className="object-contain"
-          />
-          <h2 className="text-lg font-bold text-white">
-            {themeText.welcomeTitle}
-          </h2>
-        </div>
-
-        <div className="flex-1 flex flex-col items-center justify-center p-6 bg-surface">
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            className="w-full max-w-md"
-          >
-            <form onSubmit={handleNameSubmit} className="space-y-4">
-              <div>
-                <label htmlFor="name" className="block text-sm font-medium mb-2 text-primary">
-                  {themeText.nameLabel}
-                </label>
-                <input
-                  id="name"
-                  type="text"
-                  value={nameInput}
-                  onChange={(e) => setNameInput(e.target.value)}
-                  className="w-full px-4 py-3 border-2 border-primary/20 rounded-xl
-                           bg-white text-primary focus:outline-none focus:border-accent
-                           placeholder:text-primary/50"
-                  placeholder={themeText.namePlaceholder}
-                  autoFocus
-                />
-              </div>
-              <motion.button
-                type="submit"
-                whileHover={{ scale: 1.02 }}
-                whileTap={{ scale: 0.98 }}
-                className="w-full bg-accent hover:bg-accent/90 text-white font-semibold py-3 px-4
-                          rounded-xl transition-colors shadow-md"
-              >
-                {themeText.startChat}
-              </motion.button>
-            </form>
-          </motion.div>
-        </div>
-
-        <div className="bg-white py-2 px-4 text-center border-t border-primary/10">
-          <p className="text-xs text-primary/60">
-            Powered by{" "}
-            <a
-              href="https://ersona.co"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-accent hover:text-accent/80 transition-colors font-medium"
-            >
-              Ersona
-            </a>
-          </p>
-        </div>
-      </div>
+      <WidgetShell
+        theme={widgetTheme}
+        showBackground={true}
+        backgroundImageUrl={config.backgroundImageUrl}
+        direction={direction}
+      >
+        <WelcomeScreen
+          theme={widgetTheme}
+          hotelName={config.hotelName}
+          logoUrl={config.logoUrl}
+          lang={currentLang}
+          nameInput={nameInput}
+          onNameInputChange={setNameInput}
+          onStart={handleNameSubmit}
+          quickActionsEnabled={config.quickActionsEnabled}
+          enabledQuickActions={config.enabledQuickActions}
+          onQuickAction={handleWelcomeQuickAction}
+          rightSlot={
+            config.showLanguageSelector ? (
+              <LanguageSelector
+                current={currentLang}
+                enabled={config.enabledLanguages}
+                onChange={setCurrentLang}
+              />
+            ) : undefined
+          }
+        />
+      </WidgetShell>
     );
   }
 
+  // ── Chat screen ─────────────────────────────────────────────────────────────
   return (
-    <div dir={widgetTheme.direction} className="flex flex-col h-dvh w-screen overflow-hidden">
-      <div className="flex items-center justify-between py-2 px-4 bg-primary">
-        <h3 className="font-semibold flex items-center gap-2 text-white text-sm">
-          <Image
-            src={widgetTheme.logoUrl}
-            priority={true}
-            alt="Logo"
-            width={24}
-            height={24}
-            className="object-contain"
-          />
-          <span>{themeText.headerTitle}</span>
-        </h3>
-        <button
-          onClick={resetChat}
-          className="text-sm text-white/80 hover:text-white transition-colors"
-        >
-          {themeText.resetButton}
-        </button>
-      </div>
+    <WidgetShell
+      theme={widgetTheme}
+      showBackground={false}
+      backgroundImageUrl={null}
+      direction={direction}
+    >
+      <ChatHeader
+        theme={widgetTheme}
+        hotelName={config.hotelName}
+        logoUrl={config.logoUrl}
+        lang={currentLang}
+        onReset={resetChat}
+        rightSlot={
+          config.showLanguageSelector ? (
+            <LanguageSelector
+              current={currentLang}
+              enabled={config.enabledLanguages}
+              onChange={setCurrentLang}
+            />
+          ) : undefined
+        }
+      />
 
-      <div className="flex-1 overflow-y-auto overscroll-contain p-4 space-y-4 bg-surface" style={{ WebkitOverflowScrolling: "touch" }}>
-        <AnimatePresence>
+      {/* Message list */}
+      <div
+        className="flex-1 overflow-y-auto px-3 py-4 space-y-4 bg-background"
+        aria-live="polite"
+        aria-atomic="false"
+      >
+        <AnimatePresence initial={false}>
           {messages.map((message, index) => (
-            <div key={message.id}>
-              <motion.div
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: -20 }}
-                className={`flex ${message.sender === "user" ? "justify-end" : "justify-start"}`}
+            <motion.div
+              key={message.id}
+              initial={{ opacity: 0, y: 6 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.18 }}
+            >
+              <MessageBubble
+                sender={message.sender}
+                text={message.text}
+                timestamp={message.timestamp}
+                direction={message.direction}
               >
-                <div
-                  dir={message.direction}
-                  className={`max-w-xs lg:max-w-md px-4 py-3 rounded-2xl shadow-sm ${
-                    message.sender === "user"
-                      ? "bg-accent text-primary"
-                      : "bg-white text-primary border border-primary/10"
-                  }`}
-                >
-                  <div className="text-sm prose prose-sm max-w-none [&>p]:m-0 [&>ul]:m-0 [&>ol]:m-0 [&>p+p]:mt-2 whitespace-pre-wrap">
-                    <Markdown
-                      components={{
-                        a: ({ href, children }) => (
-                          <MarkdownLink href={href} isUserMessage={message.sender === "user"}>
-                            {children}
-                          </MarkdownLink>
-                        ),
-                        strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
-                        em: ({ children }) => <em className="italic">{children}</em>,
-                      }}
-                    >
-                      {message.text}
-                    </Markdown>
-                  </div>
-                  <p className={`text-xs mt-2 ${
-                    message.sender === "user" ? "text-primary/60" : "text-primary/50"
-                  }`}>
-                    {message.timestamp.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
-                  </p>
-                </div>
-              </motion.div>
+                {/* Form rendering based on formId */}
+                {message.formId === WidgetFormId.CONTACT_INFO && (
+                  <ContactForm
+                    lang={currentLang}
+                    onSubmit={handleContactFormSubmit}
+                    disabled={isLoading}
+                  />
+                )}
+                {message.formId === WidgetFormId.FATTAL_ID_COLLECT && (
+                  <FattalIdCollectForm
+                    lang={currentLang}
+                    onSubmit={handleContactFormSubmit}
+                    disabled={isLoading}
+                  />
+                )}
+                {message.formId === WidgetFormId.FATTAL_OTP_VERIFY && (
+                  <FattalOtpVerifyForm
+                    lang={currentLang}
+                    onSubmit={handleContactFormSubmit}
+                    disabled={isLoading}
+                  />
+                )}
+                {message.formId === WidgetFormId.FATTAL_CANCELLATION_CONFIRM && (
+                  <FattalCancellationForm
+                    lang={currentLang}
+                    onSubmit={handleContactFormSubmit}
+                    disabled={isLoading}
+                    formData={
+                      message.formData as React.ComponentProps<
+                        typeof FattalCancellationForm
+                      >["formData"]
+                    }
+                  />
+                )}
+                {message.formId === WidgetFormId.FATTAL_CONTACT_UPDATE && (
+                  <FattalContactUpdateForm
+                    lang={currentLang}
+                    onSubmit={
+                      handleContactFormSubmit as React.ComponentProps<
+                        typeof FattalContactUpdateForm
+                      >["onSubmit"]
+                    }
+                    disabled={isLoading}
+                    formData={
+                      message.formData as React.ComponentProps<
+                        typeof FattalContactUpdateForm
+                      >["formData"]
+                    }
+                  />
+                )}
+                {message.formId === WidgetFormId.GUESTY_GUEST_DETAILS && (
+                  <GuestDetailsForm
+                    lang={currentLang}
+                    onSubmit={handleContactFormSubmit}
+                    disabled={isLoading}
+                    formData={
+                      message.formData as React.ComponentProps<
+                        typeof GuestDetailsForm
+                      >["formData"]
+                    }
+                  />
+                )}
 
-              {message.formId === WidgetFormId.CONTACT_INFO && (
-                <ContactForm
-                  lang={currentLang}
-                  onSubmit={handleContactFormSubmit}
-                  disabled={isLoading}
-                />
-              )}
-              {message.formId === WidgetFormId.FATTAL_ID_COLLECT && (
-                <FattalIdCollectForm
-                  lang={currentLang}
-                  onSubmit={handleContactFormSubmit}
-                  disabled={isLoading}
-                />
-              )}
-              {message.formId === WidgetFormId.FATTAL_OTP_VERIFY && (
-                <FattalOtpVerifyForm
-                  lang={currentLang}
-                  onSubmit={handleContactFormSubmit}
-                  disabled={isLoading}
-                />
-              )}
-              {message.formId === WidgetFormId.FATTAL_CANCELLATION_CONFIRM && (
-                <FattalCancellationForm
-                  lang={currentLang}
-                  onSubmit={handleContactFormSubmit}
-                  disabled={isLoading}
-                  formData={message.formData as React.ComponentProps<typeof FattalCancellationForm>["formData"]}
-                />
-              )}
-              {message.formId === WidgetFormId.FATTAL_CONTACT_UPDATE && (
-                <FattalContactUpdateForm
-                  lang={currentLang}
-                  onSubmit={handleContactFormSubmit as React.ComponentProps<typeof FattalContactUpdateForm>["onSubmit"]}
-                  disabled={isLoading}
-                  formData={message.formData as React.ComponentProps<typeof FattalContactUpdateForm>["formData"]}
-                />
-              )}
-              {message.formId === WidgetFormId.GUESTY_GUEST_DETAILS && (
-                <GuestDetailsForm
-                  lang={currentLang}
-                  onSubmit={handleContactFormSubmit}
-                  disabled={isLoading}
-                  formData={message.formData as React.ComponentProps<typeof GuestDetailsForm>["formData"]}
-                />
-              )}
+                {/* Hotel Carousel (Fattal) */}
+                {message.hotelOptions && message.hotelOptions.length > 0 && (
+                  <HotelCarousel
+                    hotels={message.hotelOptions}
+                    onSelectHotel={handleSelectHotel}
+                    lang={currentLang}
+                  />
+                )}
 
-              {message.hotelOptions && message.hotelOptions.length > 0 && (
-                <HotelCarousel hotels={message.hotelOptions} onSelectHotel={handleSelectHotel} lang={currentLang} />
-              )}
-
-              {message.roomSearchResults && message.roomSearchResults.length > 0 && (
-                <>
-                  {selectedFattalRooms.get(index) ? (
-                    <FattalRoomDetailView
-                      room={selectedFattalRooms.get(index)!}
-                      onConfirm={(room, pkg, price, isClubMember) =>
-                        handleConfirmFattalRoom(index, room, pkg, price, isClubMember)
-                      }
-                      onBack={() => handleBackFromFattalRoom(index)}
-                      lang={currentLang}
-                    />
-                  ) : (
-                    <FattalRoomCarousel
-                      rooms={message.roomSearchResults}
-                      onSelectRoom={(room) => handleSelectFattalRoom(index, room)}
-                      lang={currentLang}
-                    />
+                {/* Fattal Room Carousel or Detail View */}
+                {message.roomSearchResults &&
+                  message.roomSearchResults.length > 0 && (
+                    <>
+                      {selectedFattalRooms.get(index) ? (
+                        <FattalRoomDetailView
+                          room={selectedFattalRooms.get(index)!}
+                          onConfirm={(room, pkg, price, isClubMember) =>
+                            handleConfirmFattalRoom(
+                              index,
+                              room,
+                              pkg,
+                              price,
+                              isClubMember
+                            )
+                          }
+                          onBack={() => handleBackFromFattalRoom(index)}
+                          lang={currentLang}
+                        />
+                      ) : (
+                        <FattalRoomCarousel
+                          rooms={message.roomSearchResults}
+                          onSelectRoom={(room) =>
+                            handleSelectFattalRoom(index, room)
+                          }
+                          lang={currentLang}
+                        />
+                      )}
+                    </>
                   )}
-                </>
-              )}
 
-              {message.listingOptions && message.listingOptions.length > 0 && (
-                <>
-                  {selectedListing ? (
-                    <ListingDetailView
-                      listing={selectedListing}
-                      onSelect={handleSelectListing}
-                      onBack={handleBackFromListingDetail}
-                      lang={currentLang}
-                    />
-                  ) : (
-                    <ListingCarousel listings={message.listingOptions} onViewDetails={handleViewListingDetails} lang={currentLang} />
+                {/* Listing Carousel or Detail View */}
+                {message.listingOptions &&
+                  message.listingOptions.length > 0 && (
+                    <>
+                      {selectedListing ? (
+                        <ListingDetailView
+                          listing={selectedListing}
+                          onSelect={handleSelectListing}
+                          onBack={handleBackFromListingDetail}
+                          lang={currentLang}
+                        />
+                      ) : (
+                        <ListingCarousel
+                          listings={message.listingOptions}
+                          onViewDetails={handleViewListingDetails}
+                          lang={currentLang}
+                        />
+                      )}
+                    </>
                   )}
-                </>
-              )}
-            </div>
+              </MessageBubble>
+            </motion.div>
           ))}
           {isLoading && (
-            <motion.div
-              initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.2, ease: "easeOut" }}
-              className="flex justify-start"
-            >
+            <div className="flex justify-start">
               <LoadingSpinner />
-            </motion.div>
+            </div>
           )}
         </AnimatePresence>
         <div ref={messagesEndRef} />
       </div>
 
-      <div className="p-4 bg-white border-t border-primary/10">
-        <form onSubmit={handleMessageSubmit} className="flex gap-2">
-          <input
-            ref={inputRef}
-            type="text"
-            value={inputMessage}
-            onChange={handleInputChange}
-            onKeyDown={handleKeyDown}
-            dir="auto"
-            className="flex-1 px-4 py-3 border-2 border-primary/20 rounded-xl
-                     bg-white text-primary focus:outline-none focus:border-accent
-                     text-sm placeholder:text-primary/40"
-            placeholder={themeText.inputPlaceholder}
-          />
-          <motion.button
-            type="submit"
-            disabled={!inputMessage.trim()}
-            whileHover={{ scale: 1.05 }}
-            whileTap={{ scale: 0.95 }}
-            className="bg-accent hover:bg-accent/90 text-white font-medium p-3
-                     rounded-xl transition-colors flex items-center justify-center
-                     disabled:opacity-50 disabled:cursor-not-allowed shadow-md"
-          >
-            <LuSendHorizontal className={`w-5 h-5 transition-transform ${widgetTheme.direction === "rtl" ? "rotate-180" : ""}`} />
-          </motion.button>
-        </form>
-      </div>
-
-      <div className="py-2 px-4 bg-white text-center">
-        <p className="text-xs text-primary/50">
-          Powered by:{" "}
-          <a
-            href="https://ersona.co"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-accent hover:text-accent/80 transition-colors font-medium"
-          >
-            Ersona
-          </a>
-        </p>
-      </div>
-    </div>
+      <Composer
+        value={inputMessage}
+        onChange={setInputMessage}
+        onSubmit={handleMessageSubmit}
+        placeholder={themeText.inputPlaceholder}
+        disabled={isLoading}
+        direction={direction}
+        formLabel={currentLang === "HE" ? "כתיבת הודעה" : "Message composer"}
+      />
+    </WidgetShell>
   );
 }

--- a/src/components/shell/BackgroundImage.tsx
+++ b/src/components/shell/BackgroundImage.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+interface BackgroundImageProps {
+  imageUrl: string | null;
+  /** CSS gradient string used when imageUrl is null or invalid */
+  defaultTreatment: string;
+  /**
+   * Adds a darkening gradient + slight blur over the image for legibility
+   * when text/UI is rendered on top. Defaults to true because the only
+   * current consumer (welcome screen) needs it.
+   */
+  overlay?: boolean;
+}
+
+const SAFE_URL_PREFIXES = ['http://', 'https://', '/', 'data:image/'];
+
+function isSafeImageUrl(url: string): boolean {
+  return SAFE_URL_PREFIXES.some((prefix) => url.startsWith(prefix));
+}
+
+export default function BackgroundImage({
+  imageUrl,
+  defaultTreatment,
+  overlay = true,
+}: BackgroundImageProps) {
+  const safeUrl = imageUrl && isSafeImageUrl(imageUrl) ? imageUrl : null;
+
+  if (safeUrl) {
+    return (
+      <div className="absolute inset-0 overflow-hidden" aria-hidden="true">
+        <div
+          className="absolute inset-0 bg-cover bg-center"
+          style={{ backgroundImage: `url("${safeUrl}")` }}
+        />
+        {overlay && (
+          <div className="absolute inset-0 bg-gradient-to-b from-black/30 via-black/10 to-black/40 backdrop-blur-[2px]" />
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="absolute inset-0"
+      style={{ background: defaultTreatment }}
+      aria-hidden="true"
+    />
+  );
+}

--- a/src/components/shell/ChatHeader.tsx
+++ b/src/components/shell/ChatHeader.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { type ReactNode } from 'react';
+import Image from 'next/image';
+import DefaultIcon from './DefaultIcon';
+import type { WidgetTheme } from '@/config/theme-config';
+import type { Language } from '@/utils/i18n';
+
+interface ChatHeaderProps {
+  theme: WidgetTheme;
+  hotelName: string | null;
+  logoUrl: string | null;
+  lang: Language;
+  onReset?: () => void;
+  /** Slot for the LanguageSelector (placed opposite the title/logo block) */
+  rightSlot?: ReactNode;
+}
+
+export default function ChatHeader({
+  theme,
+  hotelName,
+  logoUrl,
+  lang,
+  onReset,
+  rightSlot,
+}: ChatHeaderProps) {
+  const effectiveLogo = logoUrl ?? theme.logoUrl;
+  const title = hotelName ?? theme.text[lang].headerTitle;
+
+  return (
+    <header className="flex items-center justify-between px-4 py-3 border-b border-border bg-surface">
+      <div className="flex items-center gap-2.5 min-w-0">
+        {effectiveLogo ? (
+          <Image
+            src={effectiveLogo}
+            alt=""
+            width={theme.logoSize.width}
+            height={theme.logoSize.height}
+            className="rounded-md object-contain shrink-0"
+          />
+        ) : (
+          <div className="shrink-0 w-7 h-7 rounded-full bg-primary text-surface flex items-center justify-center">
+            <DefaultIcon size={16} />
+          </div>
+        )}
+        <span className="text-sm font-semibold text-text truncate">{title}</span>
+      </div>
+
+      <div className="flex items-center gap-1">
+        {rightSlot}
+        {onReset && (
+          <button
+            type="button"
+            onClick={onReset}
+            className="text-xs text-text/60 hover:text-text px-2 py-1 rounded-md hover:bg-text/5"
+          >
+            {theme.text[lang].resetButton}
+          </button>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/src/components/shell/Composer.tsx
+++ b/src/components/shell/Composer.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { type FormEvent, type ReactNode, useRef } from 'react';
+import { LuSendHorizontal, LuPaperclip } from 'react-icons/lu';
+
+interface ComposerProps {
+  value: string;
+  onChange: (next: string) => void;
+  onSubmit: () => void;
+  placeholder: string;
+  disabled?: boolean;
+  /** Slot for suggested-action chips rendered above the input */
+  chipsSlot?: ReactNode;
+  direction?: 'ltr' | 'rtl';
+  /** Accessible label for the form element */
+  formLabel?: string;
+}
+
+export default function Composer({
+  value,
+  onChange,
+  onSubmit,
+  placeholder,
+  disabled = false,
+  chipsSlot,
+  direction,
+  formLabel = 'Message composer',
+}: ComposerProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (disabled) return;
+    if (!value.trim()) return;
+    onSubmit();
+    // Refocus the input after sending so the user can keep typing without
+    // reaching for the mouse/keyboard reset.
+    inputRef.current?.focus();
+  }
+
+  return (
+    <div className="border-t border-border bg-surface px-3 pt-2 pb-3 space-y-2">
+      {chipsSlot}
+      <form onSubmit={handleSubmit} aria-label={formLabel} className="flex items-center gap-2">
+        <button
+          type="button"
+          aria-label="Attach (coming soon)"
+          aria-disabled="true"
+          disabled
+          className="shrink-0 w-9 h-9 rounded-full text-text/30 flex items-center justify-center cursor-not-allowed"
+        >
+          <LuPaperclip className="w-4 h-4" />
+        </button>
+        <input
+          ref={inputRef}
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          disabled={disabled}
+          dir={direction}
+          className="flex-1 px-3 py-2 rounded-full bg-text/5 text-text placeholder:text-text/40 focus:outline-none focus:ring-2 focus:ring-primary/30 text-sm"
+        />
+        <button
+          type="submit"
+          disabled={disabled || !value.trim()}
+          aria-label="Send"
+          className="shrink-0 w-9 h-9 rounded-full bg-primary text-surface flex items-center justify-center disabled:opacity-40 hover:bg-primary-light transition-colors"
+        >
+          <LuSendHorizontal className="w-4 h-4 rtl:rotate-180" />
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/components/shell/DefaultIcon.tsx
+++ b/src/components/shell/DefaultIcon.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+interface DefaultIconProps {
+  size?: number;
+  className?: string;
+}
+
+export default function DefaultIcon({ size = 28, className = '' }: DefaultIconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M12 4a1 1 0 0 1 1 1v1.07a7.002 7.002 0 0 1 6 6.93V16h.5a1.5 1.5 0 0 1 0 3h-15a1.5 1.5 0 0 1 0-3H5v-3a7.002 7.002 0 0 1 6-6.93V5a1 1 0 0 1 1-1Z"
+        fill="currentColor"
+      />
+      <rect x="9" y="20" width="6" height="2" rx="1" fill="currentColor" />
+    </svg>
+  );
+}

--- a/src/components/shell/LanguageSelector.tsx
+++ b/src/components/shell/LanguageSelector.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { LuGlobe, LuCheck } from 'react-icons/lu';
+import { type Language, t } from '@/utils/i18n';
+
+interface LanguageSelectorProps {
+  current: Language;
+  enabled: Language[];
+  onChange: (lang: Language) => void;
+}
+
+const LANGUAGE_LABELS: Record<Language, string> = {
+  HE: 'עברית',
+  EN: 'English',
+};
+
+export default function LanguageSelector({
+  current,
+  enabled,
+  onChange,
+}: LanguageSelectorProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const menuLabel = t(current, 'languageSelectorLabel');
+
+  useEffect(() => {
+    if (!open) return;
+    function onClick(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('mousedown', onClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  if (enabled.length <= 1) return null;
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={menuLabel}
+        className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-full text-xs font-medium text-text/80 hover:bg-text/5 transition-colors"
+      >
+        <LuGlobe className="w-4 h-4" aria-hidden="true" />
+        <span className="uppercase">{current}</span>
+      </button>
+
+      {open && (
+        <ul
+          role="menu"
+          aria-label={menuLabel}
+          className="absolute end-0 mt-1.5 min-w-[10rem] rounded-xl bg-surface border border-border shadow-lg overflow-hidden z-50"
+        >
+          {enabled.map((lang) => (
+            <li key={lang} role="none">
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  onChange(lang);
+                  setOpen(false);
+                }}
+                className="w-full flex items-center justify-between px-3 py-2 text-sm text-text hover:bg-text/5"
+              >
+                <span>{LANGUAGE_LABELS[lang]}</span>
+                {lang === current && (
+                  <LuCheck className="w-4 h-4 text-primary" aria-hidden="true" />
+                )}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/shell/MessageBubble.tsx
+++ b/src/components/shell/MessageBubble.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { type ReactNode } from 'react';
+import Markdown from 'react-markdown';
+import DefaultIcon from './DefaultIcon';
+
+interface MessageBubbleProps {
+  sender: 'user' | 'bot';
+  text: string;
+  timestamp: Date;
+  direction: 'ltr' | 'rtl';
+  /** Slot for rich content rendered below the text (carousels, forms) */
+  children?: ReactNode;
+}
+
+function formatTime(d: Date): string {
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+export default function MessageBubble({
+  sender,
+  text,
+  timestamp,
+  direction,
+  children,
+}: MessageBubbleProps) {
+  const isUser = sender === 'user';
+
+  return (
+    <div
+      className={`flex gap-2 items-end ${isUser ? 'flex-row-reverse' : 'flex-row'}`}
+    >
+      <div
+        className={`shrink-0 w-7 h-7 rounded-full flex items-center justify-center ${
+          isUser
+            ? 'bg-text/10 text-text/70'
+            : 'bg-primary text-surface'
+        }`}
+        aria-hidden="true"
+      >
+        {isUser ? (
+          <span className="text-xs font-medium">U</span>
+        ) : (
+          <DefaultIcon size={16} />
+        )}
+      </div>
+
+      <div className={`max-w-[85%] flex flex-col gap-1 ${isUser ? 'items-end' : 'items-start'}`}>
+        {text && (
+          <div
+            dir={direction}
+            className={`px-3.5 py-2.5 rounded-2xl text-sm leading-relaxed ${
+              isUser
+                ? 'bg-primary text-surface rounded-br-md'
+                : 'bg-surface text-text border border-border rounded-bl-md shadow-sm'
+            }`}
+          >
+            {isUser ? (
+              <p className="m-0 whitespace-pre-wrap break-words">{text}</p>
+            ) : (
+              <div className="prose prose-sm max-w-none [&_p]:m-0 [&_p+p]:mt-2 [&_a]:underline">
+                <Markdown>{text}</Markdown>
+              </div>
+            )}
+          </div>
+        )}
+        {children && <div className="w-full">{children}</div>}
+        <time
+          dateTime={timestamp.toISOString()}
+          className="text-[10px] text-text/40 px-1"
+        >
+          {formatTime(timestamp)}
+        </time>
+      </div>
+    </div>
+  );
+}

--- a/src/components/shell/QuickActions.tsx
+++ b/src/components/shell/QuickActions.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { LuCalendarCheck, LuTag, LuGift } from 'react-icons/lu';
+import type { ReactNode } from 'react';
+import type { Language } from '@/utils/i18n';
+import type { QuickActionId } from '@/config/widget-config';
+import { getQuickActionLabel } from '@/config/quick-actions';
+
+interface QuickActionsProps {
+  enabled: QuickActionId[];
+  lang: Language;
+  variant: 'welcome' | 'chat';
+  onSelect: (id: QuickActionId) => void;
+}
+
+const ICONS: Record<QuickActionId, ReactNode> = {
+  availability: <LuCalendarCheck className="w-4 h-4" aria-hidden="true" />,
+  prices: <LuTag className="w-4 h-4" aria-hidden="true" />,
+  packages: <LuGift className="w-4 h-4" aria-hidden="true" />,
+};
+
+export default function QuickActions({
+  enabled,
+  lang,
+  variant,
+  onSelect,
+}: QuickActionsProps) {
+  if (enabled.length === 0) return null;
+
+  if (variant === 'welcome') {
+    return (
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+        {enabled.map((id) => (
+          <button
+            key={id}
+            type="button"
+            onClick={() => onSelect(id)}
+            className="flex items-center justify-center gap-2 px-3 py-2.5 rounded-xl border border-border bg-surface hover:bg-accent-light transition-colors text-sm font-medium text-text"
+          >
+            {ICONS[id]}
+            <span>{getQuickActionLabel(id, lang)}</span>
+          </button>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex gap-2 overflow-x-auto pb-1 -mx-1 px-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+      {enabled.map((id) => (
+        <button
+          key={id}
+          type="button"
+          onClick={() => onSelect(id)}
+          className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-full border border-border bg-surface hover:bg-accent-light transition-colors text-xs font-medium text-text"
+        >
+          {ICONS[id]}
+          <span>{getQuickActionLabel(id, lang)}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/shell/WelcomeScreen.tsx
+++ b/src/components/shell/WelcomeScreen.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { type FormEvent, type ReactNode, useRef, useState } from 'react';
+import Image from 'next/image';
+import { motion } from 'framer-motion';
+import DefaultIcon from './DefaultIcon';
+import QuickActions from './QuickActions';
+import type { WidgetTheme } from '@/config/theme-config';
+import { type Language, t } from '@/utils/i18n';
+import type { QuickActionId } from '@/config/widget-config';
+
+const NAME_ERROR_CLEAR_MS = 700;
+
+interface WelcomeScreenProps {
+  theme: WidgetTheme;
+  hotelName: string | null;
+  logoUrl: string | null;
+  lang: Language;
+  nameInput: string;
+  onNameInputChange: (next: string) => void;
+  onStart: (e: FormEvent) => void;
+  quickActionsEnabled: boolean;
+  enabledQuickActions: QuickActionId[];
+  onQuickAction: (id: QuickActionId) => void;
+  /** Slot for the LanguageSelector (header area) */
+  rightSlot?: ReactNode;
+}
+
+export default function WelcomeScreen({
+  theme,
+  hotelName,
+  logoUrl,
+  lang,
+  nameInput,
+  onNameInputChange,
+  onStart,
+  quickActionsEnabled,
+  enabledQuickActions,
+  onQuickAction,
+  rightSlot,
+}: WelcomeScreenProps) {
+  const themeText = theme.text[lang];
+  const effectiveLogo = logoUrl ?? theme.logoUrl;
+  const displayedTitle =
+    hotelName != null && hotelName.length > 0
+      ? lang === 'HE'
+        ? `ברוכים הבאים ל${hotelName}`
+        : `Welcome to ${hotelName}`
+      : themeText.welcomeTitle;
+  const subtitle = t(lang, 'welcomeSubtitle');
+
+  const [nameError, setNameError] = useState(false);
+  const errorClearTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  function clearErrorTimer() {
+    if (errorClearTimer.current) {
+      clearTimeout(errorClearTimer.current);
+      errorClearTimer.current = null;
+    }
+  }
+
+  function handleNameChange(value: string) {
+    if (nameError) {
+      clearErrorTimer();
+      setNameError(false);
+    }
+    onNameInputChange(value);
+  }
+
+  function handleQuickActionAttempt(id: QuickActionId) {
+    if (!nameInput.trim()) {
+      clearErrorTimer();
+      setNameError(true);
+      errorClearTimer.current = setTimeout(() => {
+        setNameError(false);
+        errorClearTimer.current = null;
+      }, NAME_ERROR_CLEAR_MS);
+      return;
+    }
+    onQuickAction(id);
+  }
+
+  return (
+    <div className="relative h-full flex flex-col">
+      <header className="flex items-center justify-between px-4 py-3">
+        <div className="flex items-center gap-2 min-w-0">
+          {effectiveLogo ? (
+            <Image
+              src={effectiveLogo}
+              alt=""
+              width={theme.logoSize.width}
+              height={theme.logoSize.height}
+              className="rounded-md object-contain shrink-0"
+            />
+          ) : (
+            <div className="shrink-0 w-7 h-7 rounded-full bg-surface/90 backdrop-blur text-primary flex items-center justify-center">
+              <DefaultIcon size={16} />
+            </div>
+          )}
+          {hotelName && (
+            <span className="text-sm font-medium text-surface/95 truncate drop-shadow">
+              {hotelName}
+            </span>
+          )}
+        </div>
+        {rightSlot}
+      </header>
+
+      <div className="flex-1 flex items-center justify-center px-4 pb-4">
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.35, ease: 'easeOut' }}
+          className="w-full max-w-md bg-surface/95 backdrop-blur rounded-2xl shadow-2xl border border-border/40 p-6 sm:p-7"
+        >
+          <div className="flex flex-col items-center text-center mb-5">
+            <div className="w-12 h-12 rounded-full bg-primary text-surface flex items-center justify-center mb-3">
+              <DefaultIcon size={24} />
+            </div>
+            <h1 className="text-xl sm:text-2xl font-semibold text-text mb-1.5">
+              {displayedTitle}
+            </h1>
+            <p className="text-sm text-text/60 leading-relaxed">{subtitle}</p>
+          </div>
+
+          <form onSubmit={onStart} className="space-y-3" aria-label="Start chat">
+            <motion.div
+              animate={nameError ? { x: [-8, 8, -6, 6, -4, 4, 0] } : { x: 0 }}
+              transition={{ duration: 0.4 }}
+            >
+              <label className="block">
+                <span className="sr-only">{themeText.nameLabel}</span>
+                <input
+                  type="text"
+                  value={nameInput}
+                  onChange={(e) => handleNameChange(e.target.value)}
+                  placeholder={themeText.namePlaceholder}
+                  aria-invalid={nameError}
+                  className={`w-full px-4 py-3 rounded-xl bg-text/[0.03] border focus:bg-surface focus:outline-none focus:ring-2 text-text placeholder:text-text/40 text-sm transition-colors ${
+                    nameError
+                      ? 'border-red-400 focus:border-red-400 focus:ring-red-300/40'
+                      : 'border-border focus:border-primary focus:ring-primary/20'
+                  }`}
+                  autoFocus
+                />
+              </label>
+            </motion.div>
+            <button
+              type="submit"
+              disabled={!nameInput.trim()}
+              className="w-full py-3 rounded-xl bg-primary text-surface font-medium text-sm hover:bg-primary-light disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {themeText.startChat}
+            </button>
+          </form>
+
+          {quickActionsEnabled && enabledQuickActions.length > 0 && (
+            <div className="mt-4">
+              <QuickActions
+                enabled={enabledQuickActions}
+                lang={lang}
+                variant="welcome"
+                onSelect={handleQuickActionAttempt}
+              />
+            </div>
+          )}
+
+          <div className="mt-5 text-center">
+            <span className="text-[10px] text-text/40 tracking-wide">
+              {t(lang, 'poweredBy')}
+            </span>
+          </div>
+        </motion.div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/shell/WidgetShell.tsx
+++ b/src/components/shell/WidgetShell.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect, type ReactNode } from 'react';
+import BackgroundImage from './BackgroundImage';
+import { applyThemeToDocument } from '@/config/apply-theme';
+import type { WidgetTheme } from '@/config/theme-config';
+
+interface WidgetShellProps {
+  theme: WidgetTheme;
+  /** When true, renders the BackgroundImage layer (welcome screen only) */
+  showBackground: boolean;
+  backgroundImageUrl: string | null;
+  /** Direction applied to the outer wrapper for RTL/LTR layout */
+  direction: 'ltr' | 'rtl';
+  children: ReactNode;
+}
+
+export default function WidgetShell({
+  theme,
+  showBackground,
+  backgroundImageUrl,
+  direction,
+  children,
+}: WidgetShellProps) {
+  useEffect(() => {
+    applyThemeToDocument(theme);
+  }, [theme.id]);
+
+  return (
+    <div
+      dir={direction}
+      className="relative h-full w-full overflow-hidden bg-background"
+    >
+      {showBackground && (
+        <BackgroundImage
+          imageUrl={backgroundImageUrl}
+          defaultTreatment={theme.defaultBackgroundTreatment}
+          overlay
+        />
+      )}
+      <div className="relative h-full w-full flex flex-col">{children}</div>
+    </div>
+  );
+}

--- a/src/config/apply-theme.ts
+++ b/src/config/apply-theme.ts
@@ -1,0 +1,16 @@
+import type { WidgetTheme } from './theme-config';
+
+export function applyThemeToDocument(theme: WidgetTheme): void {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  root.style.setProperty('--theme-primary', theme.colors.primary);
+  root.style.setProperty('--theme-primary-light', theme.colors.primaryLight);
+  root.style.setProperty('--theme-secondary', theme.colors.secondary);
+  root.style.setProperty('--theme-accent', theme.colors.accent);
+  root.style.setProperty('--theme-accent-light', theme.colors.accentLight);
+  root.style.setProperty('--theme-background', theme.colors.background);
+  root.style.setProperty('--theme-surface', theme.colors.surface);
+  root.style.setProperty('--theme-text', theme.colors.text);
+  root.style.setProperty('--theme-border', theme.colors.border);
+  root.style.setProperty('--theme-bg-treatment', theme.defaultBackgroundTreatment);
+}

--- a/src/config/quick-actions.ts
+++ b/src/config/quick-actions.ts
@@ -1,0 +1,82 @@
+import type { Language } from '@/utils/i18n';
+import type { QuickActionId } from './widget-config';
+
+export interface QuickActionMeta {
+  id: QuickActionId;
+  label: Record<Language, string>;
+  /**
+   * Prompt template per language. Supports `{start}` and `{end}` placeholders that
+   * get substituted with the closest weekend dates at click time.
+   */
+  prompt: Record<Language, string>;
+}
+
+export const QUICK_ACTIONS: Record<QuickActionId, QuickActionMeta> = {
+  availability: {
+    id: 'availability',
+    label: { HE: 'בדיקת זמינות', EN: 'Availability' },
+    prompt: {
+      HE: 'אשמח לבדוק זמינות לתאריכים {start} עד {end}',
+      EN: "I'd like to check availability from {start} to {end}",
+    },
+  },
+  prices: {
+    id: 'prices',
+    label: { HE: 'מחירים', EN: 'Prices' },
+    prompt: {
+      HE: 'מה המחירים לתאריכים {start} עד {end}?',
+      EN: 'What are the prices for {start} to {end}?',
+    },
+  },
+  packages: {
+    id: 'packages',
+    label: { HE: 'חבילות', EN: 'Packages' },
+    prompt: {
+      HE: 'אילו חבילות זמינות לתאריכים {start} עד {end}?',
+      EN: 'What packages are available for {start} to {end}?',
+    },
+  },
+};
+
+/**
+ * Returns the closest upcoming Thursday at midnight local time.
+ * If today is Thursday, returns today. Otherwise returns the next Thursday.
+ * Skips the current weekend if today is Fri/Sat/Sun (booking past dates makes no sense).
+ */
+function getClosestThursday(now: Date = new Date()): Date {
+  const today = new Date(now);
+  today.setHours(0, 0, 0, 0);
+  const dayOfWeek = today.getDay(); // 0=Sun, 1=Mon, ..., 4=Thu, 6=Sat
+  const daysToThursday = (4 - dayOfWeek + 7) % 7;
+  today.setDate(today.getDate() + daysToThursday);
+  return today;
+}
+
+/**
+ * Format a date for display in the user-typed bubble.
+ * HE: "16.5" (Israeli short form, no year). EN: "May 16".
+ */
+function formatWeekendDate(date: Date, lang: Language): string {
+  if (lang === 'HE') {
+    return `${date.getDate()}.${date.getMonth() + 1}`;
+  }
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+  }).format(date);
+}
+
+export function getQuickActionPrompt(id: QuickActionId, lang: Language): string {
+  const start = getClosestThursday();
+  const end = new Date(start);
+  end.setDate(start.getDate() + 2); // Thu + 2 = Saturday (2-night stay)
+  const startStr = formatWeekendDate(start, lang);
+  const endStr = formatWeekendDate(end, lang);
+  return QUICK_ACTIONS[id].prompt[lang]
+    .replace('{start}', startStr)
+    .replace('{end}', endStr);
+}
+
+export function getQuickActionLabel(id: QuickActionId, lang: Language): string {
+  return QUICK_ACTIONS[id].label[lang];
+}

--- a/src/config/resolve-widget-config.ts
+++ b/src/config/resolve-widget-config.ts
@@ -1,0 +1,131 @@
+import {
+  type WidgetConfig,
+  type QuickActionId,
+  ALL_QUICK_ACTIONS,
+  DEFAULT_WIDGET_CONFIG,
+} from './widget-config';
+import type { Language } from '@/utils/i18n';
+
+// Fetches widget configuration from the chat service by widgetId.
+// Falls back to safe defaults on any failure so the widget always renders.
+
+const VALID_LANGUAGES: Language[] = ['HE', 'EN'];
+const VALID_QUICK_ACTIONS = new Set<QuickActionId>(ALL_QUICK_ACTIONS);
+const FALLBACK_WIDGET_ID = 'default';
+
+interface WidgetConfigResponse {
+  widgetId: string;
+  selectedTheme: string;
+  hotelName: string | null;
+  logoUrl: string | null;
+  backgroundImageUrl: string | null;
+  enabledLanguages: string[];
+  defaultLanguage: string;
+  showLanguageSelector: boolean;
+  quickActionsEnabled: boolean;
+  enabledQuickActions: string[];
+}
+
+function defaultsForWidgetId(widgetId: string): WidgetConfig {
+  return {
+    ...DEFAULT_WIDGET_CONFIG,
+    widgetId,
+  };
+}
+
+function normalizeLanguages(raw: string[]): Language[] {
+  const filtered = raw
+    .map((l) => l.toUpperCase())
+    .filter((l): l is Language => VALID_LANGUAGES.includes(l as Language));
+  return filtered.length > 0 ? filtered : ['HE', 'EN'];
+}
+
+function normalizeQuickActions(raw: string[]): QuickActionId[] {
+  const filtered = raw.filter((qa): qa is QuickActionId =>
+    VALID_QUICK_ACTIONS.has(qa as QuickActionId)
+  );
+  return filtered.length > 0 ? filtered : [...ALL_QUICK_ACTIONS];
+}
+
+function fromResponse(res: WidgetConfigResponse): WidgetConfig {
+  const enabledLanguages = normalizeLanguages(res.enabledLanguages);
+  const defaultLanguage = enabledLanguages.includes(
+    res.defaultLanguage.toUpperCase() as Language
+  )
+    ? (res.defaultLanguage.toUpperCase() as Language)
+    : enabledLanguages[0];
+
+  const config: WidgetConfig = {
+    widgetId: res.widgetId,
+    hotelName: res.hotelName,
+    selectedTheme: res.selectedTheme,
+    enabledLanguages,
+    defaultLanguage,
+    showLanguageSelector: res.showLanguageSelector,
+    logoUrl: res.logoUrl,
+    backgroundImageUrl: res.backgroundImageUrl,
+    quickActionsEnabled: res.quickActionsEnabled,
+    enabledQuickActions: normalizeQuickActions(res.enabledQuickActions),
+  };
+
+  if (process.env.NODE_ENV !== 'production') {
+    assertWidgetConfig(config);
+  }
+
+  return config;
+}
+
+export async function resolveWidgetConfig(
+  params: URLSearchParams
+): Promise<WidgetConfig> {
+  const widgetId = params.get('widgetId');
+
+  if (!widgetId) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(
+        '[WidgetConfig] No widgetId in URL — rendering defaults; encoder calls will not route'
+      );
+    }
+    return defaultsForWidgetId(FALLBACK_WIDGET_ID);
+  }
+
+  const baseUrl = process.env.NEXT_PUBLIC_CHAT_SERVICE_URL;
+  if (!baseUrl) {
+    console.error(
+      '[WidgetConfig] NEXT_PUBLIC_CHAT_SERVICE_URL is not set; falling back to defaults'
+    );
+    return defaultsForWidgetId(widgetId);
+  }
+
+  try {
+    const res = await fetch(
+      `${baseUrl}/api/widget-config/${encodeURIComponent(widgetId)}`
+    );
+    if (!res.ok) {
+      console.error(
+        `[WidgetConfig] Chat service returned ${res.status} for widgetId=${widgetId}; using defaults`
+      );
+      return defaultsForWidgetId(widgetId);
+    }
+    const body = (await res.json()) as WidgetConfigResponse;
+    return fromResponse(body);
+  } catch (error) {
+    console.error('[WidgetConfig] Fetch failed, using defaults', error);
+    return defaultsForWidgetId(widgetId);
+  }
+}
+
+function assertWidgetConfig(config: WidgetConfig): void {
+  if (!config.widgetId) {
+    console.error('[WidgetConfig] widgetId resolved to empty string');
+  }
+  if (config.enabledLanguages.length === 0) {
+    console.error('[WidgetConfig] enabledLanguages is empty after parsing');
+  }
+  if (!config.enabledLanguages.includes(config.defaultLanguage)) {
+    console.error(
+      `[WidgetConfig] defaultLanguage ${config.defaultLanguage} not in enabledLanguages`,
+      config.enabledLanguages
+    );
+  }
+}

--- a/src/config/theme-config.ts
+++ b/src/config/theme-config.ts
@@ -16,161 +16,364 @@ export interface WidgetThemeText {
   loadingPlaceholder: string;
 }
 
+export interface WidgetThemeColors {
+  primary: string;
+  secondary: string;
+  accent: string;
+  background: string;
+  surface: string;
+  text: string;
+  border: string;
+  primaryLight: string;
+  accentLight: string;
+}
+
 export interface WidgetTheme {
   id: string;
-  colors: {
-    primary: string;
-    primaryLight: string;
-    accent: string;
-    background: string;
-    accentLight: string;
-  };
-  logoUrl: string;
+  displayName: string;
+  defaultDirection: 'rtl' | 'ltr';
+  colors: WidgetThemeColors;
+  logoUrl: string | null;
+  defaultIcon: 'concierge-bell';
   logoSize: { width: number; height: number };
-  direction: "rtl" | "ltr";
+  backgroundImageUrl: string | null;
+  defaultBackgroundTreatment: string;
   text: Record<Language, WidgetThemeText>;
   welcomeMessage: (name: string) => WelcomeMessage;
 }
 
-const HEBREW_RE = /[\u0590-\u05FF]/;
+const HEBREW_RE = /[֐-׿]/;
 const isHebrew = (s: string) => HEBREW_RE.test(s);
 const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
 
 const defaultTheme: WidgetTheme = {
-  id: "default",
+  id: 'default',
+  displayName: 'Default',
+  defaultDirection: 'ltr',
   colors: {
-    primary: "#1A3A5C",
-    primaryLight: "#244E75",
-    accent: "#2685CB",
-    background: "#FFFFFF",
-    accentLight: "#EBF5FF",
+    primary: '#1A3A5C',
+    primaryLight: '#244E75',
+    secondary: '#244E75',
+    accent: '#2685CB',
+    accentLight: '#EBF5FF',
+    background: '#F8F7F3',
+    surface: '#FFFFFF',
+    text: '#0E1726',
+    border: '#D9E1EA',
   },
-  logoUrl: "/ersona-logo.svg",
+  logoUrl: '/ersona-logo.svg',
+  defaultIcon: 'concierge-bell',
   logoSize: { width: 24, height: 24 },
-  direction: "ltr",
+  backgroundImageUrl: null,
+  defaultBackgroundTreatment:
+    'linear-gradient(135deg, #1A3A5C 0%, #244E75 60%, #2685CB 100%)',
   text: {
     EN: {
-      welcomeTitle: "Welcome",
-      headerTitle: "Chat with us",
-      nameLabel: "Please enter your name:",
-      namePlaceholder: "Your name...",
-      startChat: "Start Chat",
-      resetButton: "Reset",
-      inputPlaceholder: "Type a message...",
-      loadingPlaceholder: "Waiting for reply...",
+      welcomeTitle: 'Welcome',
+      headerTitle: 'Chat with us',
+      nameLabel: 'Please enter your name:',
+      namePlaceholder: 'Your name...',
+      startChat: 'Start Chat',
+      resetButton: 'Reset',
+      inputPlaceholder: 'Type a message...',
+      loadingPlaceholder: 'Waiting for reply...',
     },
     HE: {
-      welcomeTitle: "ברוכים הבאים",
-      headerTitle: "צ׳אט איתנו",
-      nameLabel: "נא להזין את שמך:",
-      namePlaceholder: "השם שלך...",
-      startChat: "התחל צ׳אט",
-      resetButton: "איפוס",
-      inputPlaceholder: "הקלד הודעה...",
-      loadingPlaceholder: "ממתין לתשובה...",
+      welcomeTitle: 'ברוכים הבאים',
+      headerTitle: 'צ׳אט איתנו',
+      nameLabel: 'נא להזין את שמך:',
+      namePlaceholder: 'השם שלך...',
+      startChat: 'התחל צ׳אט',
+      resetButton: 'איפוס',
+      inputPlaceholder: 'הקלד הודעה...',
+      loadingPlaceholder: 'ממתין לתשובה...',
     },
   },
   welcomeMessage: (name) =>
     isHebrew(name)
       ? {
           text: `היי ${name}, ברוכים הבאים!\nאיך נוכל לעזור לך היום?`,
-          direction: "rtl",
+          direction: 'rtl',
         }
       : {
           text: `Hi ${capitalize(name)}, welcome!\nHow can we help you today?`,
-          direction: "ltr",
+          direction: 'ltr',
         },
 };
 
 const fattalTheme: WidgetTheme = {
-  id: "fattal",
+  id: 'fattal',
+  displayName: 'Fattal Hotels',
+  defaultDirection: 'rtl',
   colors: {
-    primary: "#1d2b4d",
-    primaryLight: "#2d3f66",
-    accent: "#f0c14b",
-    background: "#faf8f5",
-    accentLight: "#fff8e1",
+    primary: '#1d2b4d',
+    primaryLight: '#2d3f66',
+    secondary: '#2d3f66',
+    accent: '#f0c14b',
+    accentLight: '#fff8e1',
+    background: '#faf8f5',
+    surface: '#FFFFFF',
+    text: '#1d2b4d',
+    border: '#E5DCC4',
   },
-  logoUrl: "https://d2nyvxq412w7ra.cloudfront.net/fattal_heart_color_addfa324af.svg",
+  logoUrl:
+    'https://d2nyvxq412w7ra.cloudfront.net/fattal_heart_color_addfa324af.svg',
+  defaultIcon: 'concierge-bell',
   logoSize: { width: 24, height: 24 },
-  direction: "rtl",
+  backgroundImageUrl: null,
+  defaultBackgroundTreatment:
+    'linear-gradient(135deg, #1d2b4d 0%, #2d3f66 50%, #f0c14b 100%)',
   text: {
     HE: {
-      welcomeTitle: "ברוכים הבאים לפתאל",
-      headerTitle: "רשת מלונות פתאל",
-      nameLabel: "נא להזין את שמך:",
-      namePlaceholder: "השם שלך...",
-      startChat: "התחל צ׳אט",
-      resetButton: "איפוס",
-      inputPlaceholder: "הקלד הודעה...",
-      loadingPlaceholder: "ממתין לתשובה...",
+      welcomeTitle: 'ברוכים הבאים לפתאל',
+      headerTitle: 'רשת מלונות פתאל',
+      nameLabel: 'נא להזין את שמך:',
+      namePlaceholder: 'השם שלך...',
+      startChat: 'התחל צ׳אט',
+      resetButton: 'איפוס',
+      inputPlaceholder: 'הקלד הודעה...',
+      loadingPlaceholder: 'ממתין לתשובה...',
     },
     EN: {
-      welcomeTitle: "Welcome to Fattal",
-      headerTitle: "Fattal Hotels",
-      nameLabel: "Please enter your name:",
-      namePlaceholder: "Your name...",
-      startChat: "Start Chat",
-      resetButton: "Reset",
-      inputPlaceholder: "Type a message...",
-      loadingPlaceholder: "Waiting for reply...",
+      welcomeTitle: 'Welcome to Fattal',
+      headerTitle: 'Fattal Hotels',
+      nameLabel: 'Please enter your name:',
+      namePlaceholder: 'Your name...',
+      startChat: 'Start Chat',
+      resetButton: 'Reset',
+      inputPlaceholder: 'Type a message...',
+      loadingPlaceholder: 'Waiting for reply...',
     },
   },
   welcomeMessage: (name) =>
     isHebrew(name)
       ? {
           text: `שלום, ${name}.\nאני יכול לעזור לך לקבל מידע על המלון, לבדוק מחירים וחבילות, לבצע הזמנה חדשה, ולטפל בהזמנה קיימת - כולל ביטול או עדכון פרטים אישיים.`,
-          direction: "rtl",
+          direction: 'rtl',
         }
       : {
           text: `Welcome, ${capitalize(name)}.\nI can help you with hotel information, rates and packages, making a new reservation, and handling an existing booking - including cancellations or updating personal details.`,
-          direction: "ltr",
+          direction: 'ltr',
         },
 };
 
 const eztlvTheme: WidgetTheme = {
-  id: "eztlv",
+  id: 'eztlv',
+  displayName: 'EZ Group',
+  defaultDirection: 'ltr',
   colors: {
-    primary: "#2D6DA4",
-    primaryLight: "#3A85C4",
-    accent: "#2D6DA4",
-    background: "#F5F7FA",
-    accentLight: "#E8F0FE",
+    primary: '#2D6DA4',
+    primaryLight: '#3A85C4',
+    secondary: '#3A85C4',
+    accent: '#2D6DA4',
+    accentLight: '#E8F0FE',
+    background: '#F5F7FA',
+    surface: '#FFFFFF',
+    text: '#14323A',
+    border: '#D5E4F0',
   },
-  logoUrl: "/ez-group.png",
+  logoUrl: '/ez-group.png',
+  defaultIcon: 'concierge-bell',
   logoSize: { width: 44, height: 44 },
-  direction: "ltr",
+  backgroundImageUrl: null,
+  defaultBackgroundTreatment:
+    'linear-gradient(135deg, #2D6DA4 0%, #3A85C4 50%, #5BC0EB 100%)',
   text: {
     EN: {
-      welcomeTitle: "Welcome to EZ Group",
-      headerTitle: "EZ Group",
-      nameLabel: "Please enter your name:",
-      namePlaceholder: "Your name...",
-      startChat: "Start Chat",
-      resetButton: "Reset",
-      inputPlaceholder: "Type a message...",
-      loadingPlaceholder: "Waiting for reply...",
+      welcomeTitle: 'Welcome to EZ Group',
+      headerTitle: 'EZ Group',
+      nameLabel: 'Please enter your name:',
+      namePlaceholder: 'Your name...',
+      startChat: 'Start Chat',
+      resetButton: 'Reset',
+      inputPlaceholder: 'Type a message...',
+      loadingPlaceholder: 'Waiting for reply...',
     },
     HE: {
-      welcomeTitle: "ברוכים הבאים ל-EZ Group",
-      headerTitle: "EZ Group",
-      nameLabel: "נא להזין את שמך:",
-      namePlaceholder: "השם שלך...",
-      startChat: "התחל צ׳אט",
-      resetButton: "איפוס",
-      inputPlaceholder: "הקלד הודעה...",
-      loadingPlaceholder: "ממתין לתשובה...",
+      welcomeTitle: 'ברוכים הבאים ל-EZ Group',
+      headerTitle: 'EZ Group',
+      nameLabel: 'נא להזין את שמך:',
+      namePlaceholder: 'השם שלך...',
+      startChat: 'התחל צ׳אט',
+      resetButton: 'איפוס',
+      inputPlaceholder: 'הקלד הודעה...',
+      loadingPlaceholder: 'ממתין לתשובה...',
     },
   },
   welcomeMessage: (name) =>
     isHebrew(name)
       ? {
           text: `היי ${name}, ברוכים הבאים ל-EZ Group!\nאני כאן כדי לעזור לך למצוא את הדירה המושלמת ולענות על כל שאלה.`,
-          direction: "rtl",
+          direction: 'rtl',
         }
       : {
           text: `Hi ${capitalize(name)}, welcome to EZ Group!\nI'm here to help you find the perfect apartment and answer any questions.`,
-          direction: "ltr",
+          direction: 'ltr',
+        },
+};
+
+const urbanTheme: WidgetTheme = {
+  id: 'urban',
+  displayName: 'Urban / Boutique',
+  defaultDirection: 'ltr',
+  colors: {
+    primary: '#0F2747',
+    primaryLight: '#274C77',
+    secondary: '#274C77',
+    accent: '#D6A85F',
+    accentLight: '#F2E5CC',
+    background: '#F8F7F3',
+    surface: '#FFFFFF',
+    text: '#0E1726',
+    border: '#D9E1EA',
+  },
+  logoUrl: null,
+  defaultIcon: 'concierge-bell',
+  logoSize: { width: 28, height: 28 },
+  backgroundImageUrl: null,
+  defaultBackgroundTreatment:
+    'linear-gradient(135deg, #0F2747 0%, #1A3A5C 60%, #274C77 100%)',
+  text: {
+    HE: {
+      welcomeTitle: 'ברוכים הבאים',
+      headerTitle: 'צ׳אט איתנו',
+      nameLabel: 'נא להזין את שמך',
+      namePlaceholder: 'השם שלך...',
+      startChat: 'התחל צ׳אט',
+      resetButton: 'איפוס',
+      inputPlaceholder: 'הקלד הודעה...',
+      loadingPlaceholder: 'ממתין לתשובה...',
+    },
+    EN: {
+      welcomeTitle: 'Welcome',
+      headerTitle: 'Chat with us',
+      nameLabel: 'Please enter your name',
+      namePlaceholder: 'Your name...',
+      startChat: 'Start Chat',
+      resetButton: 'Reset',
+      inputPlaceholder: 'Type a message...',
+      loadingPlaceholder: 'Waiting for reply...',
+    },
+  },
+  welcomeMessage: (name) =>
+    isHebrew(name)
+      ? {
+          text: `היי ${name}, ברוכים הבאים! איך נוכל לעזור לך היום?`,
+          direction: 'rtl',
+        }
+      : {
+          text: `Hi ${capitalize(name)}, welcome! How can we help you today?`,
+          direction: 'ltr',
+        },
+};
+
+const resortTheme: WidgetTheme = {
+  id: 'resort',
+  displayName: 'Resort / Coastal',
+  defaultDirection: 'ltr',
+  colors: {
+    primary: '#1F9AA8',
+    primaryLight: '#5BC0EB',
+    secondary: '#5BC0EB',
+    accent: '#D9B26F',
+    accentLight: '#DFF4F1',
+    background: '#FAFCFB',
+    surface: '#FFFFFF',
+    text: '#14323A',
+    border: '#D5E8E8',
+  },
+  logoUrl: null,
+  defaultIcon: 'concierge-bell',
+  logoSize: { width: 28, height: 28 },
+  backgroundImageUrl: null,
+  defaultBackgroundTreatment:
+    'linear-gradient(135deg, #DFF4F1 0%, #5BC0EB 50%, #1F9AA8 100%)',
+  text: {
+    HE: {
+      welcomeTitle: 'ברוכים הבאים',
+      headerTitle: 'צ׳אט איתנו',
+      nameLabel: 'נא להזין את שמך',
+      namePlaceholder: 'השם שלך...',
+      startChat: 'התחל צ׳אט',
+      resetButton: 'איפוס',
+      inputPlaceholder: 'הקלד הודעה...',
+      loadingPlaceholder: 'ממתין לתשובה...',
+    },
+    EN: {
+      welcomeTitle: 'Welcome',
+      headerTitle: 'Chat with us',
+      nameLabel: 'Please enter your name',
+      namePlaceholder: 'Your name...',
+      startChat: 'Start Chat',
+      resetButton: 'Reset',
+      inputPlaceholder: 'Type a message...',
+      loadingPlaceholder: 'Waiting for reply...',
+    },
+  },
+  welcomeMessage: (name) =>
+    isHebrew(name)
+      ? {
+          text: `היי ${name}, ברוכים הבאים! איך נוכל לעזור לך היום?`,
+          direction: 'rtl',
+        }
+      : {
+          text: `Hi ${capitalize(name)}, welcome! How can we help you today?`,
+          direction: 'ltr',
+        },
+};
+
+const luxuryTheme: WidgetTheme = {
+  id: 'luxury',
+  displayName: 'Classic Luxury',
+  defaultDirection: 'ltr',
+  colors: {
+    primary: '#5B0F1B',
+    primaryLight: '#7A1F2B',
+    secondary: '#7A1F2B',
+    accent: '#D4AF6A',
+    accentLight: '#F2E2C2',
+    background: '#FAF6F0',
+    surface: '#FFFDFC',
+    text: '#2C1A15',
+    border: '#E7D8C7',
+  },
+  logoUrl: null,
+  defaultIcon: 'concierge-bell',
+  logoSize: { width: 28, height: 28 },
+  backgroundImageUrl: null,
+  defaultBackgroundTreatment:
+    'linear-gradient(135deg, #FAF6F0 0%, #D4AF6A 50%, #5B0F1B 100%)',
+  text: {
+    HE: {
+      welcomeTitle: 'ברוכים הבאים',
+      headerTitle: 'צ׳אט איתנו',
+      nameLabel: 'נא להזין את שמך',
+      namePlaceholder: 'השם שלך...',
+      startChat: 'התחל צ׳אט',
+      resetButton: 'איפוס',
+      inputPlaceholder: 'הקלד הודעה...',
+      loadingPlaceholder: 'ממתין לתשובה...',
+    },
+    EN: {
+      welcomeTitle: 'Welcome',
+      headerTitle: 'Chat with us',
+      nameLabel: 'Please enter your name',
+      namePlaceholder: 'Your name...',
+      startChat: 'Start Chat',
+      resetButton: 'Reset',
+      inputPlaceholder: 'Type a message...',
+      loadingPlaceholder: 'Waiting for reply...',
+    },
+  },
+  welcomeMessage: (name) =>
+    isHebrew(name)
+      ? {
+          text: `היי ${name}, ברוכים הבאים! איך נוכל לעזור לך היום?`,
+          direction: 'rtl',
+        }
+      : {
+          text: `Hi ${capitalize(name)}, welcome! How can we help you today?`,
+          direction: 'ltr',
         },
 };
 
@@ -178,9 +381,12 @@ export const themes: Record<string, WidgetTheme> = {
   default: defaultTheme,
   fattal: fattalTheme,
   eztlv: eztlvTheme,
+  urban: urbanTheme,
+  resort: resortTheme,
+  luxury: luxuryTheme,
 };
 
-export const DEFAULT_THEME_ID = "default";
+export const DEFAULT_THEME_ID = 'urban';
 
 export function getTheme(themeId?: string | null): WidgetTheme {
   if (themeId && themes[themeId]) {

--- a/src/config/widget-config.ts
+++ b/src/config/widget-config.ts
@@ -1,0 +1,32 @@
+import type { Language } from '@/utils/i18n';
+
+export type QuickActionId = 'availability' | 'prices' | 'packages';
+
+export const ALL_QUICK_ACTIONS: QuickActionId[] = ['availability', 'prices', 'packages'];
+
+export interface WidgetConfig {
+  widgetId: string | null;
+  companyId: string;
+  hotelName: string | null;
+  selectedTheme: string;
+  enabledLanguages: Language[];
+  defaultLanguage: Language;
+  showLanguageSelector: boolean;
+  logoUrl: string | null;
+  backgroundImageUrl: string | null;
+  quickActionsEnabled: boolean;
+  enabledQuickActions: QuickActionId[];
+}
+
+export const DEFAULT_WIDGET_CONFIG: Omit<WidgetConfig, 'companyId'> = {
+  widgetId: null,
+  hotelName: null,
+  selectedTheme: 'urban',
+  enabledLanguages: ['HE', 'EN'],
+  defaultLanguage: 'HE',
+  showLanguageSelector: true,
+  logoUrl: null,
+  backgroundImageUrl: null,
+  quickActionsEnabled: true,
+  enabledQuickActions: ['availability', 'prices', 'packages'],
+};

--- a/src/config/widget-config.ts
+++ b/src/config/widget-config.ts
@@ -5,8 +5,7 @@ export type QuickActionId = 'availability' | 'prices' | 'packages';
 export const ALL_QUICK_ACTIONS: QuickActionId[] = ['availability', 'prices', 'packages'];
 
 export interface WidgetConfig {
-  widgetId: string | null;
-  companyId: string;
+  widgetId: string;
   hotelName: string | null;
   selectedTheme: string;
   enabledLanguages: Language[];
@@ -18,8 +17,7 @@ export interface WidgetConfig {
   enabledQuickActions: QuickActionId[];
 }
 
-export const DEFAULT_WIDGET_CONFIG: Omit<WidgetConfig, 'companyId'> = {
-  widgetId: null,
+export const DEFAULT_WIDGET_CONFIG: Omit<WidgetConfig, 'widgetId'> = {
   hotelName: null,
   selectedTheme: 'urban',
   enabledLanguages: ['HE', 'EN'],

--- a/src/services/message-queue-service.ts
+++ b/src/services/message-queue-service.ts
@@ -8,7 +8,6 @@ import { pushPendingMessage } from './redis-service';
  * (Replaces sendPusherMessage - same signature for minimal changes to callers)
  */
 export async function queueAgentMessage(
-  companyId: string,
   conversationId: string,
   message: string,
   timestamp?: string,
@@ -39,12 +38,11 @@ export async function queueAgentMessage(
  * (Replaces sendPusherFallbackMessage)
  */
 export async function queueFallbackMessage(
-  companyId: string,
   conversationId: string,
   fallbackMessage?: string
 ): Promise<void> {
   const message =
     fallbackMessage ||
     "I'm sorry, I'm having trouble processing your message right now. Please try again later.";
-  await queueAgentMessage(companyId, conversationId, message);
+  await queueAgentMessage(conversationId, message);
 }

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -25,6 +25,12 @@ export const translations = {
     select: 'בחר',
     startingFrom: 'החל מ-',
     back: 'חזרה',
+    welcomeSubtitle: 'בדיקת זמינות, מחירים וחבילות — במהירות ובקלות',
+    quickActionAvailability: 'בדיקת זמינות',
+    quickActionPrices: 'מחירים',
+    quickActionPackages: 'חבילות',
+    languageSelectorLabel: 'שפה',
+    poweredBy: 'Powered by Ersona',
 
     // Hotel Carousel
     availableHotels: 'מלונות זמינים',
@@ -137,6 +143,12 @@ export const translations = {
     select: 'Select',
     startingFrom: 'From ',
     back: 'Back',
+    welcomeSubtitle: 'Check availability, rates and packages — fast and easy',
+    quickActionAvailability: 'Availability',
+    quickActionPrices: 'Prices',
+    quickActionPackages: 'Packages',
+    languageSelectorLabel: 'Language',
+    poweredBy: 'Powered by Ersona',
 
     // Hotel Carousel
     availableHotels: 'Available Hotels',

--- a/test-cross-origin.html
+++ b/test-cross-origin.html
@@ -55,6 +55,6 @@
     </div>
     
     <!-- For now, load from same origin but this demonstrates the concept -->
-    <script id="ersona-chat-widget" src="http://localhost:3000/chat-widget.js" data-company-id="widget_e97rtkce6"></script>
+    <script id="ersona-chat-widget" src="http://localhost:3000/chat-widget.js" data-widget-id="widget_e97rtkce6"></script>
 </body>
 </html>

--- a/test-embed.html
+++ b/test-embed.html
@@ -124,8 +124,8 @@
         });
     </script>
 
-    <!-- Your chat widget script with companyId (using ID + data attribute method) -->
-    <!-- <script id="ersona-chat-widget" src="http://localhost:3000/chat-widget.js" data-company-id="widget_e97rtkce6"></script> -->
-    <script id="ersona-chat-widget" src="https://cs-chat-widget-lymo.vercel.app/chat-widget.js" data-company-id="widget_e97rtkce6"></script>
+    <!-- Your chat widget script with widgetId (using ID + data attribute method) -->
+    <!-- <script id="ersona-chat-widget" src="http://localhost:3000/chat-widget.js" data-widget-id="widget_e97rtkce6"></script> -->
+    <script id="ersona-chat-widget" src="http://localhost:3000/chat-widget.js" data-widget-id="widget_e97rt12sf"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Major widget redesign session covering three intertwined feature sets:

### 1. Visual redesign + configurable themes
- Three new themes (`urban` [default], `resort`, `luxury`); legacy themes (`default`, `fattal`, `eztlv`) backfilled into expanded `WidgetTheme` schema with new tokens (secondary, surface, text, border, defaultIcon, defaultBackgroundTreatment).
- New shell components under `src/components/shell/`: `WidgetShell`, `WelcomeScreen`, `ChatHeader`, `MessageBubble`, `Composer`, `LanguageSelector`, `QuickActions`, `BackgroundImage`, `DefaultIcon` (concierge bell SVG).
- `ChatWidget.tsx` and `FullPageChatWidget.tsx` refactored to compose the new shell while preserving postMessage / polling / send-receive / rich-content rendering.
- Iframe enlarged 350×500 → 380×640 to fit welcome card content.
- Quick action chips (welcome-screen-only) with dynamic prompts referencing the closest weekend (Thu→Sat) per locale.
- Name-required validation with shake animation + red border on quick action click.
- Welcome → chat morph: welcome card scales 1 → 1.08 + fades (350ms), chat fades in (250ms), first message bubble slides in (180ms). Single `WidgetShell` wraps both states.
- `/preview` route added for developer visual spot-checking.

### 2. Mode B — widget config from chat service
- `cs-chat-widget` resolver is now async, fetches widget config from `GET {chat-service}/api/widget-config/:widgetId` (chat-service implementation lives on a separate worktree branch `feat/widget-visual-config-mode-b`).
- Loader (`chat-widget.js`) simplified — only `data-widget-id` forwarded as URL param to the iframe (legacy `data-company-id` accepted as a script-tag fallback).
- Mode A URL params (`theme`, `hotelName`, `logoUrl`, `bgUrl`, `enabledLanguages`, `enabledQuickActions`) no longer accepted by the resolver — chat-service is the only source of visual config.
- Loading state added to `/embed-chat` and `/booking` pages while config fetches.
- Failure modes degrade gracefully (missing widgetId, fetch error, missing chat-service URL) — widget renders defaults + console.error.

### 3. companyId → widgetId rename
- All internal types, variables, route handlers, server actions, services renamed.
- `companyId` literal preserved at exactly two encoder-boundary spots:
  - Outgoing: `POST {EMBEDDINGS_SERVICE_URL}/widget/message` body still sends `{ companyId: data.widgetId, ... }`.
  - Incoming: `POST /api/widget/response` destructure-renames the encoder's `companyId` field to `widgetId`.
- Comments at both spots explain why the literal survives there.
- `message-queue-service` dropped its unused `companyId` parameter entirely.

### 4. Merged from PR #30 (`feat/widget-gallery`)
- `GalleryCard`, `GalleryLightbox`, `useImageNavigation` hook, `WidgetGallery` types.
- Gallery passthrough at every layer (chat-widget.js → /api/widget/messages → encoder → /api/widget/response → queue → poll → render).
- Gallery rendered inside `MessageBubble` children slot; lightbox is a top-level overlay inside `WidgetShell`.

### 5. Floating button cleanup
- Removed dead 3-theme `themeColors` map from `chat-widget.js`; floating button now uses a single neutral navy color (no per-theme HTTP fetch needed for a 60px circle).
- Loader collapsed from 56 LOC of getter helpers to 9 LOC (only `getDataAttr` + `getWidgetId` survive; dead `getTheme` removed; `getCompanyId` and `getLanguage` inlined into a single dataset lookup).

### Tokens-only sweep
- Hardcoded gray/blue classes in `FattalCancellationForm`, `FattalContactUpdateForm` swapped for theme tokens.

### Untouched (firm boundaries kept)
- All `/api/widget/*` routes (only `messages`/`response`/`checkout` got their internal contract renamed; no behavior change).
- Encoder integration, payload shapes, message flow.
- All form submission logic, all carousel rendering logic.
- `WidgetFormId` enum.
- Pusher SDK (still installed; runtime delivery is Redis queue + polling/postMessage).

## Test plan

- [ ] `/embed-chat?widgetId=widget_xxx` — async config fetch + welcome screen + name validation + quick action shake + welcome→chat morph + first message
- [ ] `/booking?widgetId=widget_xxx` — same flow on full-page surface + polling
- [ ] All 6 themes render correctly: `default`, `fattal`, `eztlv`, `urban`, `resort`, `luxury`
- [ ] Language selector switches HE/EN mid-conversation; direction flips correctly
- [ ] Quick action chips inject the dynamic-date prompts in the correct language
- [ ] Quick actions on welcome page are centered when 1 or 2 are enabled (3 = full row)
- [ ] Hotel/room/listing carousels still render; all 6 forms still render
- [ ] Gallery card renders inline; lightbox opens on click
- [ ] Existing customer themes (`fattal`, `eztlv`) visually unchanged
- [ ] `chat-widget.js` loader is backward compatible — existing scripts with `data-company-id` (legacy) still work, recommended new pattern is `data-widget-id`
- [ ] Encoder integration intact (sends `companyId` field on the wire to `/widget/message`; receives `companyId` field on `/api/widget/response` callback)
- [ ] Mode B endpoint reachable from local widget when `NEXT_PUBLIC_CHAT_SERVICE_URL` is set
- [ ] Failure modes work: missing widgetId → defaults; chat service down → defaults + console.error

## Coordinated work

- Chat service implementation of the Mode B endpoint + admin form lives on `nextjs-messenger-clone:feat/widget-visual-config-mode-b` (separate PR).
- No encoder changes required for this PR — the widget→company resolution already happens server-side via the existing `findCompanyByContactMethod('WIDGET', value)` lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)