### PR TITLE
ci: deploy via GitHub OIDC (ersona-gha-deploy)

### DIFF
--- a/.github/workflows/aws-dev.yml
+++ b/.github/workflows/aws-dev.yml
@@ -45,11 +45,10 @@ jobs:
         node-version: 21
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-region: ${{ env.AWS_REGION }}
-        aws-access-key-id: ${{ secrets.AWS_ECR_ACCESS_KEY_ERSONA }}
-        aws-secret-access-key: ${{ secrets.AWS_ECR_ACCESS_SECRET_ERSONA }}
+        role-to-assume: arn:aws:iam::448866508458:role/ersona-gha-deploy
 
     - name: Login to Amazon ECR
       id: login-ecr

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -45,11 +45,10 @@ jobs:
         node-version: 21
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-region: ${{ env.AWS_REGION }}
-        aws-access-key-id: ${{ secrets.AWS_ECR_ACCESS_KEY_ERSONA }}
-        aws-secret-access-key: ${{ secrets.AWS_ECR_ACCESS_SECRET_ERSONA }}
+        role-to-assume: arn:aws:iam::448866508458:role/ersona-gha-deploy
 
     - name: Login to Amazon ECR
       id: login-ecr


### PR DESCRIPTION
Swaps the shared static AWS keys for the `ersona-gha-deploy` OIDC role (configure-aws-credentials@v4) in aws.yml + aws-dev.yml. No other steps change. Prereq (already applied): ersona-gha-deploy role + aws-auth mapRoles in ersona-infra. Validated end-to-end on guest-app (PR #16).