### PR TITLE
Add PDB + prod nodeSelector for node isolation (EKS upgrade pre-gate)

### DIFF
--- a/.github/workflows/aws-dev.yml
+++ b/.github/workflows/aws-dev.yml
@@ -190,7 +190,8 @@ jobs:
         
         echo "Applying Deployment..."
         kubectl apply -f ./k8s/deployment.yaml
-        
+        kubectl apply -f ./k8s/pdb.yaml
+
         echo "Applying Service..."
         kubectl apply -f ./k8s/service.yaml
         

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -171,6 +171,7 @@ jobs:
         find ./k8s -type f -name "*.yaml" -exec sed -i 's/namespace: .*/namespace: ${{ env.NAMESPACE }}/g' {} \;
         find ./k8s -type f -name "*.yaml" -exec sed -i 's/app.kubernetes.io\/namespace: .*/app.kubernetes.io\/namespace: ${{ env.NAMESPACE }}/g' {} \;
         find ./k8s -type f -name "network-policy.yaml" -exec sed -i 's/namespace: .*/namespace: ${{ env.NAMESPACE }}/g' {} \;
+        find ./k8s -type f -name "*.yaml" -exec sed -i 's/environment: dev/environment: prod/g' {} \;
         echo "Namespace updated in all manifest files"
 
     - name: Update HPA manifest
@@ -209,7 +210,8 @@ jobs:
         
         echo "Applying Deployment..."
         kubectl apply -f ./k8s/deployment.yaml
-        
+        kubectl apply -f ./k8s/pdb.yaml
+
         echo "Applying Service..."
         kubectl apply -f ./k8s/service.yaml
         

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -21,6 +21,15 @@ spec:
       labels:
         app: cs-chat-widget
     spec:
+      nodeSelector:
+        environment: dev
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: cs-chat-widget
       containers:
       - name: cs-chat-widget
         image: 448866508458.dkr.ecr.eu-north-1.amazonaws.com/dev/cs-chat-widget:latest # For local. For EKS, use ECR URL: {account-id}.dkr.ecr.eu-north-1.amazonaws.com/cs-chat-widget:{tag}

--- a/k8s/pdb.yaml
+++ b/k8s/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cs-chat-widget-pdb
+  namespace: dev
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: cs-chat-widget


### PR DESCRIPTION
## What
Adds a PodDisruptionBudget (maxUnavailable: 1) and a prod nodeSelector + soft topologySpreadConstraints to cs-chat-widget.

## Why
Pre-gate for the EKS 1.30->1.34 upgrade node rolls: the PDB keeps >=1 replica up during drains; the nodeSelector (environment: dev, flipped to prod by the prod pipeline sed) stops prod pods from landing on dev SPOT nodes; topology spread separates the 2 prod replicas across hosts.

## Changes
- new k8s/pdb.yaml
- k8s/deployment.yaml: nodeSelector + topologySpreadConstraints
- aws.yml: environment dev->prod sed + apply pdb.yaml
- aws-dev.yml: apply pdb.yaml

PR targets dev; merge to main after review. 🤖 Generated with Claude Code