### PR TITLE
fix(SCRUM-1102): render guest contact form on full-page chat (/booking)

### DIFF
--- a/src/components/FullPageChatWidget.tsx
+++ b/src/components/FullPageChatWidget.tsx
@@ -82,6 +82,12 @@ export default function FullPageChatWidget({
 
   const [userName, setUserName] = useState<string>("");
   const [nameInput, setNameInput] = useState<string>("");
+  // Guest contact collected on the welcome screen (SCRUM-1089). Forwarded to the
+  // encoder via meta so it can be persisted on the conversation (SCRUM-1090).
+  const [collectedContact, setCollectedContact] = useState<{
+    email?: string;
+    phone?: string;
+  }>({});
   const [messages, setMessages] = useState<Message[]>([]);
   const [inputMessage, setInputMessage] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -205,6 +211,20 @@ export default function FullPageChatWidget({
             message,
             userName: currentUserName,
             timestamp: new Date().toISOString(),
+            // Welcome-screen contact (SCRUM-1089) travels as conversation metadata
+            // so the encoder persists it on the conversation (SCRUM-1090).
+            ...(collectedContact.phone || collectedContact.email
+              ? {
+                  meta: {
+                    ...(collectedContact.phone
+                      ? { guestPhone: collectedContact.phone }
+                      : {}),
+                    ...(collectedContact.email
+                      ? { guestEmail: collectedContact.email }
+                      : {}),
+                  },
+                }
+              : {}),
             ...(formData ? { formData } : {}),
           }),
         });
@@ -215,7 +235,7 @@ export default function FullPageChatWidget({
         setIsLoading(false);
       }
     },
-    [config.widgetId, startPolling]
+    [config.widgetId, startPolling, collectedContact.phone, collectedContact.email]
   );
 
   // Post a user bubble and forward to encoder — shared by text submit and quick actions
@@ -237,11 +257,17 @@ export default function FullPageChatWidget({
   );
 
   // Handle name submission (form submit — no quick action)
-  const handleNameSubmit = (e: React.FormEvent) => {
+  const handleNameSubmit = (
+    e: React.FormEvent,
+    contact?: { email?: string; phone?: string }
+  ) => {
     e.preventDefault();
     if (!nameInput.trim()) return;
 
     setUserName(nameInput.trim());
+    if (contact && (contact.email || contact.phone)) {
+      setCollectedContact(contact);
+    }
 
     const welcome = widgetTheme.welcomeMessage(nameInput.trim());
     const welcomeMessage: Message = {
@@ -481,6 +507,10 @@ export default function FullPageChatWidget({
               nameInput={nameInput}
               onNameInputChange={setNameInput}
               onStart={handleNameSubmit}
+              showEmail={config.showEmail}
+              emailRequired={config.emailRequired}
+              showPhone={config.showPhone}
+              phoneRequired={config.phoneRequired}
               quickActionsEnabled={config.quickActionsEnabled}
               enabledQuickActions={config.enabledQuickActions}
               onQuickAction={handleWelcomeQuickAction}


### PR DESCRIPTION
## SCRUM-1102 — render guest contact form on full-page chat (/booking)

Fixes a bug shipped to production: the guest email/phone contact form (SCRUM-1089) renders in the embedded widget but was missing from the full-page booking chat (`FullPageChatWidget`).

### Root cause
1. `FullPageChatWidget` didn't pass `showEmail/emailRequired/showPhone/phoneRequired` to `WelcomeScreen` → fields never rendered.
2. `handleNameSubmit` dropped the collected contact → email/phone never sent as `meta.guestPhone/guestEmail` (so the encoder couldn't persist it, SCRUM-1090).

### Changes (`src/components/FullPageChatWidget.tsx`)
- Pass the 4 contact-config props to `WelcomeScreen`.
- Accept + store the collected contact in `handleNameSubmit` (`collectedContact` state).
- Forward `guestPhone/guestEmail` as conversation `meta` in the send call, matching the embed `ChatWidget` path.

### Verification
- `npx tsc --noEmit` ✅ clean
- `eslint` on the file ✅ (only a pre-existing unrelated warning)
- Frontend-only — no DB migrations, no new env vars, backward compatible.

Jira: https://editease5.atlassian.net/browse/SCRUM-1102

🤖 Generated with [Claude Code](https://claude.com/claude-code)